### PR TITLE
Shipit -> Azkaban integration

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,4 @@
 deploy:
     override:
         - mvn clean package
-        - scp camus-shopify/target/*.jar deploy@hadoop-etl1.chi.shopify.com:/u/apps/camus
+        - /etc/azkaban/azkaban-submit-job


### PR DESCRIPTION
Instead of copying a jar file to the server, bad bad :) we now upload the jar directly to Azkaban so that we have a simple pipeline where deploying a new version of Camus means that it gets uploaded and scheduled as well. 
