### PR TITLE
Statsd integration for Camus

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>commons-httpclient</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.indeed</groupId>
+            <artifactId>java-dogstatsd-client</artifactId>
+            <version>2.0.8</version>
+        </dependency>
     </dependencies>
 
     <!-- 	<build> -->

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -1,11 +1,11 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.linkedin.camus.coders.Partitioner;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.coders.DefaultPartitioner;
+import com.linkedin.camus.etl.kafka.common.AvroRecordWriterProvider;
+import com.linkedin.camus.etl.kafka.common.DateUtils;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
@@ -16,12 +16,11 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.format.DateTimeFormatter;
 
-import com.linkedin.camus.coders.Partitioner;
-import com.linkedin.camus.etl.RecordWriterProvider;
-import com.linkedin.camus.etl.kafka.coders.DefaultPartitioner;
-import com.linkedin.camus.etl.kafka.common.AvroRecordWriterProvider;
-import com.linkedin.camus.etl.kafka.common.DateUtils;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * MultipleAvroOutputFormat.
@@ -84,7 +83,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
                 .getClass(ETL_RECORD_WRITER_PROVIDER_CLASS,
                         AvroRecordWriterProvider.class);
     }
-    
+
     public static RecordWriterProvider getRecordWriterProvider(JobContext job) {
         try
         {
@@ -133,7 +132,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static long getMonitorTimeGranularityMs(JobContext job) {
       return job.getConfiguration().getInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, 10) * 60000L;
     }
-    
+
     public static void setEtlAvroWriterSyncInterval(JobContext job, int val) {
         job.getConfiguration().setInt(ETL_AVRO_WRITER_SYNC_INTERVAL, val);
     }
@@ -186,14 +185,14 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
         Partitioner partitioner = getPartitioner(context, key.getTopic());
         return "data." + key.getTopic().replaceAll("\\.", "_") + "." + key.getLeaderId() + "." + key.getPartition() + "." + partitioner.encodePartition(context, key);
     }
-    
+
     public static void setDefaultPartitioner(JobContext job, Class<?> cls) {
       job.getConfiguration().setClass(ETL_DEFAULT_PARTITIONER_CLASS, cls, Partitioner.class);
     }
-    
+
     public static Partitioner getDefaultPartitioner(JobContext job) {
         return ReflectionUtils.newInstance(job.getConfiguration().getClass(ETL_DEFAULT_PARTITIONER_CLASS, DefaultPartitioner.class, Partitioner.class), job.getConfiguration());
-    }    
+    }
 
     public static Partitioner getPartitioner(JobContext job, String topicName) throws IOException {
         String customPartitionerProperty = ETL_DEFAULT_PARTITIONER_CLASS + "." + topicName;

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -12,6 +12,8 @@ import com.linkedin.camus.etl.kafka.common.KafkaReader;
 import java.io.IOException;
 import java.util.HashSet;
 
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import kafka.message.Message;
 
 import org.apache.hadoop.fs.ChecksumException;
@@ -30,6 +32,10 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     private static final String PRINT_MAX_DECODER_EXCEPTIONS = "max.decoder.exceptions.to.print";
     private static final String DEFAULT_SERVER = "server";
     private static final String DEFAULT_SERVICE = "service";
+    private static final String STATSD_ENABLED = "statsd.enabled";
+    private static final String STATSD_HOST = "statsd.host";
+    private static final String STATSD_PORT = "statsd.port";
+
     private TaskAttemptContext context;
 
     private Mapper<EtlKey, Writable, EtlKey, Writable>.Context mapperContext;
@@ -57,6 +63,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     EtlSplit split;
     private static Logger log = Logger.getLogger(EtlRecordReader.class);
 
+    private static boolean statsdEnabled;
+    private static StatsDClient statsd;
+
     /**
      * Record reader to fetch directly from Kafka
      *
@@ -67,6 +76,16 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     public EtlRecordReader(InputSplit split, TaskAttemptContext context) throws IOException,
             InterruptedException {
         initialize(split, context);
+        this.statsdEnabled = getStatsdEnabled(context);
+
+        if (this.statsdEnabled) {
+            this.statsd = new NonBlockingStatsDClient(
+                    "Camus",
+                    getStatsdHost(context),
+                    getStatsdPort(context),
+                    new String[]{"camus:exceptions"}
+            );
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -102,7 +121,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         } else {
             beginTimeStamp = 0;
         }
-        
+
         ignoreServerServiceList = new HashSet<String>();
         for(String ignoreServerServiceTopic : EtlInputFormat.getEtlAuditIgnoreServiceTopicList(context))
         {
@@ -124,6 +143,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         try {
             r = decoder.decode(payload);
         } catch (Exception e) {
+            if (this.statsdEnabled) {
+                statsd.incrementCounter(topicName.concat(":" + e.getMessage()));
+            }
             if (!skipSchemaErrors) {
                 throw new IOException(e);
             }
@@ -242,9 +264,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
                     long checksum = key.getChecksum();
                     if (checksum != messageWithKey.checksum() && checksum != messageWithoutKey.checksum()) {
                     	throw new ChecksumException("Invalid message checksum : MessageWithKey : "
-                              + messageWithKey.checksum() + " MessageWithoutKey checksum : " 
-                    		  + messageWithoutKey.checksum() 
-                    		  + ". Expected " + key.getChecksum(),	
+                              + messageWithKey.checksum() + " MessageWithoutKey checksum : "
+                    		  + messageWithoutKey.checksum()
+                    		  + ". Expected " + key.getChecksum(),
                     		  key.getOffset());
                     }
 
@@ -338,7 +360,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             }
         }
     }
-    
+
     public void setServerService()
     {
     	if(ignoreServerServiceList.contains(key.getTopic()) || ignoreServerServiceList.contains("all"))
@@ -351,4 +373,17 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     public static int getMaximumDecoderExceptionsToPrint(JobContext job) {
         return job.getConfiguration().getInt(PRINT_MAX_DECODER_EXCEPTIONS, 10);
     }
+
+    public static Boolean getStatsdEnabled(JobContext job) {
+        return job.getConfiguration().getBoolean(STATSD_ENABLED, false);
+    }
+
+    public static String getStatsdHost(JobContext job) {
+        return job.getConfiguration().get(STATSD_HOST, "localhost");
+    }
+
+    public static int getStatsdPort(JobContext job) {
+        return job.getConfiguration().getInt(STATSD_PORT, 8125);
+    }
+
 }

--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -35,7 +35,7 @@ kafka.message.coder.schema.registry.class=com.linkedin.camus.example.DummySchema
 mapred.map.tasks=30
 # max historical time that will be pulled from each partition based on event timestamp
 kafka.max.pull.hrs=1
-# events with a timestamp older than this will be discarded. 
+# events with a timestamp older than this will be discarded.
 kafka.max.historical.days=3
 # Max minutes for each mapper to pull messages (-1 means no limit)
 kafka.max.pull.minutes.per.task=-1
@@ -95,3 +95,8 @@ kafka.client.so.timeout=60000
 
 #zookeeper.session.timeout=
 #zookeeper.connection.timeout=
+
+#statsd datadog integration
+statsd.enabled=false
+statsd.host=localhost
+statsd.port=8125


### PR DESCRIPTION
This PR introduces the optional ability to send metrics to a Datadog / Statsd
enabled backend. For now, it will increment a counter per topic for each JSON
parsing error it encounters and send all Hadoop level collected counters.

@wvanbergen @honkfestival @airhorns 
