### PR TITLE
Add custom entry point to Camus that can be called by Azkaban2

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -169,6 +169,16 @@ public class CamusJob extends Configured implements Tool {
 		}
 	}
 
+    public void runFromAzkaban() throws Exception {
+        String camusPropertiesPath = System.getProperty("sun.java.command").split("-P ")[1];
+        Properties camusProperties = new Properties();
+        InputStream fis = new FileInputStream(camusPropertiesPath);
+        camusProperties.load(fis);
+        fis.close();
+        this.props.putAll(camusProperties);
+        run();
+    }
+
 	public void run() throws Exception {
 
 		startTiming("pre-setup");


### PR DESCRIPTION
Add custom entry point to Camus that can be called by Azkaban2

Azkaban2 using the HadoopJava plugin cannot launch a Camus job,
see bug report https://github.com/azkaban/azkaban-plugins/issues/132

This PR adds a method runFromAzkaban() to the CamusJob class that
needs to be specified in the method.run argument in Azkaban job
properties file. The runFromAzkaban() will load the Camus specific
properties from a file and then invoke the regular Camus run()
method.

This is not something we will upstream for obvious reasons but it
does fix the problem.

@yagnik @wvanbergen @airhorns 
