### PR TITLE
Do not replace dots with underscores in topic names when constructing filename

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -183,7 +183,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
     public static String getWorkingFileName(JobContext context, EtlKey key) throws IOException {
         Partitioner partitioner = getPartitioner(context, key.getTopic());
-        return "data." + key.getTopic().replaceAll("\\.", "_") + "." + key.getLeaderId() + "." + key.getPartition() + "." + partitioner.encodePartition(context, key);
+        return "data." + key.getTopic() + "." + key.getLeaderId() + "." + key.getPartition() + "." + partitioner.encodePartition(context, key);
     }
 
     public static void setDefaultPartitioner(JobContext job, Class<?> cls) {


### PR DESCRIPTION
Some of our topic names contain dots. When generating the workingFilename,
Camus replaces all dots in a topic with underscores. This complicates our
migration away from Albert to Camus. Hence let's stop doing this.

In general, there has been a discussion in the Kafka community whether
dots, underscores and dashes should be banned from topic names as
it complicates writing JMX / Mbeans based monitoring tools for Kafka. The
current consensus seems to be that dots, underscores and dashes are okay.

See:
http://search-hadoop.com/m/4TaT4SHanu1&subj=Re+MBeans+dashes+underscores+and+KAFKA+1481
http://search-hadoop.com/m/4TaT4Jf1Jz1&subj=Re+Need+Document+and+Explanation+Of+New+Metrics+Name+in+New+Java+Producer+on+Kafka+Trunk
https://issues.apache.org/jira/browse/KAFKA-1481

@yagnik @airhorns @wvanbergen 
