### PR TITLE
Do not replace dots with underscores in topic names when constructing path

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/ShopifyPartitioner.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/ShopifyPartitioner.java
@@ -25,7 +25,7 @@ public class ShopifyPartitioner extends Partitioner {
     @Override
     public String generatePartitionedPath(JobContext context, String topic, String brokerId, int partitionId, String encodedPartition) {
         StringBuilder sb = new StringBuilder();
-        sb.append(topic).append("/");
+        sb.append(topic.replaceAll("_", "\\.")).append("/");
         DateTime bucket = new DateTime(Long.valueOf(encodedPartition));
         sb.append(bucket.toString(outputDateFormatter));
         return sb.toString();

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
@@ -1,15 +1,8 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.common.EtlCounts;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -21,9 +14,15 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import com.linkedin.camus.etl.RecordWriterProvider;
-import com.linkedin.camus.etl.kafka.common.EtlCounts;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class EtlMultiOutputCommitter extends FileOutputCommitter {
     private Pattern workingFileMetadataPattern;
@@ -125,7 +124,7 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
         offsetWriter.close();
         super.commitTask(context);
     }
-    
+
     protected void commitFile(JobContext job, Path source, Path target) throws IOException{
       FileSystem.get(job.getConfiguration()).rename(source, target);
     }
@@ -147,8 +146,8 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
         return partitionedPath +
                     "/" + topic + "." + leaderId + "." + partition +
                     "." + count+
-                    "." + offset + 
-                    "." + encodedPartition + 
+                    "." + offset +
+                    "." + encodedPartition +
                     recordWriterProvider.getFilenameExtension();
     }
 }


### PR DESCRIPTION
Some of our topic names contain dots. When generating the path,
Camus replaces all dots in a topic with underscores. This complicates our
migration away from Albert to Camus. Hence let's stop doing this.

In general, there has been a discussion in the Kafka community whether
dots, underscores and dashes should be banned from topic names as
it complicates writing JMX / Mbeans based monitoring tools for Kafka. The
current consensus seems to be that dots, underscores and dashes are okay.

See:
http://search-hadoop.com/m/4TaT4SHanu1&subj=Re+MBeans+dashes+underscores+and+KAFKA+1481
http://search-hadoop.com/m/4TaT4Jf1Jz1&subj=Re+Need+Document+and+Explanation+Of+New+Metrics+Name+in+New+Java+Producer+on+Kafka+Trunk
https://issues.apache.org/jira/browse/KAFKA-1481

@yagnik 
