### PR TITLE
Camus at shopify

### DIFF
--- a/camus-shopify/README.md
+++ b/camus-shopify/README.md
@@ -1,0 +1,20 @@
+# Installation
+
+Build Shopify's version of Camus using:
+```bash
+mvn clean package
+```
+
+This will create a shaded jar in the camus-shopify/target/ folder.
+
+# Run (for testing purposes)
+
+Copy the file camus-shopify-0.1.0-shopify1.jar to a Hadoop node using scp.
+
+Then launch Camus using the following command:
+```bash
+java -Xms64M -Xmx256M -cp /etc/camus:/etc/hadoop/conf:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop/lib/*:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop/.//*:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop-hdfs/./:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop-hdfs/lib/*:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop-hdfs/.//*:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop-yarn/lib/*:/u/cloudera/parcels/CDH-4.4.0-1.cdh4.4.0.p0.39/lib/hadoop/libexec/../../hadoop-yarn/.//*:/u/cloudera/parcels/CDH/lib/hadoop-0.20-mapreduce/./:/u/cloudera/parcels/CDH/lib/hadoop-0.20-mapreduce/lib/*:/u/cloudera/parcels/CDH/lib/hadoop-0.20-mapreduce/.//*:camus-shopify-0.1.0-shopify1.jar com.linkedin.camus.shopify.ShopifyCamysJob -P /u/apps/camus/shared/camus.properties
+```
+
+# Deploy
+Shipit -> https://shipit.shopify.com/shopify/camus/production

--- a/camus-shopify/pom.xml
+++ b/camus-shopify/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.linkedin.camus</groupId>
+        <artifactId>camus-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.shopify.camus</groupId>
+    <artifactId>camus-shopify</artifactId>
+    <version>0.1.0-shopify1</version>
+    <name>Camus Shopify</name>
+    <description>
+        This subproject exists to build a shaded jar that is usesable on Shopify's cluster.
+        It depends only on what is needed from other Camus subprojects to generate a shaded jar.
+    </description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.linkedin.camus</groupId>
+            <artifactId>camus-etl-kafka</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.linkedin.camus</groupId>
+            <artifactId>camus-sweeper</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>*</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>log4j:log4j:*</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>commons-beanutils:commons-beanutils:*</exclude>
+                                    <exclude>com.github.sgroschupf:zkclient:*</exclude>
+                                    <exclude>org.mortbay.jetty:servlet-api:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/camus-shopify/src/main/java/com/linkedin/camus/shopify/ShopifyPartitioner.java
+++ b/camus-shopify/src/main/java/com/linkedin/camus/shopify/ShopifyPartitioner.java
@@ -1,0 +1,69 @@
+package com.linkedin.camus.shopify;
+
+import com.linkedin.camus.etl.Partitioner;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.kafka.common.DateUtils;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+
+
+public class ShopifyPartitioner extends Partitioner {
+
+    protected static final String OUTPUT_DATE_FORMAT = "YYYY/MM/dd";
+    protected DateTimeFormatter outputDateFormatter = null;
+
+    @Override
+    public String encodePartition(JobContext context, IEtlKey etlKey) {
+        long outfilePartitionMs = EtlMultiOutputFormat.getEtlOutputFileTimePartitionMins(context) * 60000L;
+        return String.valueOf(DateUtils.getPartition(outfilePartitionMs, etlKey.getTime(), outputDateFormatter.getZone()));
+    }
+
+    @Override
+    public String generatePartitionedPath(JobContext context, String topic, String encodedPartition) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(topic.replaceAll("_", "\\.")).append("/");
+        DateTime bucket = new DateTime(Long.valueOf(encodedPartition));
+        sb.append(bucket.toString(outputDateFormatter));
+        return sb.toString();
+    }
+
+    @Override
+    public void setConf(Configuration conf)
+    {
+        if (conf != null){
+            outputDateFormatter = DateUtils.getDateTimeFormatter(OUTPUT_DATE_FORMAT, DateTimeZone.forID(conf.get(EtlMultiOutputFormat.ETL_DEFAULT_TIMEZONE, "America/Los_Angeles")));
+        }
+
+        super.setConf(conf);
+    }
+
+    @Override
+    public String getWorkingFileName(JobContext context, String topic, String brokerId, int partitionId,
+        String encodedPartition) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("data.").append(topic.replaceAll("\\.", "_"));
+      sb.append(".").append(brokerId);
+      sb.append(".").append(partitionId);
+      sb.append(".").append(encodedPartition);
+
+      return sb.toString();
+    }
+
+    @Override
+    public String generateFileName(JobContext context, String topic, String brokerId, int partitionId, int count,
+        long offset, String encodedPartition) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(topic);
+      sb.append(".").append(brokerId);
+      sb.append(".").append(partitionId);
+      sb.append(".").append(count);
+      sb.append(".").append(offset);
+      sb.append(".").append(encodedPartition);
+
+      return sb.toString();
+    }
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  java:
+    version: openjdk7
+
+dependencies:
+    override:
+        - bash -c "exit 0"
+
+test:
+    override:
+        - mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -73,17 +73,27 @@
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
-				<version>1.6</version>
+				<version>2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>1.0.3</version>
+				<version>2.0.0-mr1-cdh4.4.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-core</artifactId>
+				<version>2.0.0-mr1-cdh4.4.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-common</artifactId>
+				<version>2.0.0-cdh4.4.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.10</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.1</version>
                 <exclusions>
                   <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -137,6 +147,7 @@
 		<module>camus-schema-registry-avro</module>
 		<module>camus-example</module>
 		<module>camus-sweeper</module>
+		<module>camus-shopify</module>
 	</modules>
 
 	<licenses>
@@ -163,6 +174,10 @@
 			<id>apache-releases</id>
 			<url>https://repository.apache.org/content/groups/public</url>
 		</repository>
+		<repository>
+                        <id>cloudera</id>
+                        <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+                </repository>
 	</repositories>
 
 	<build>
@@ -200,6 +215,11 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+    override:
+        - mvn clean package
+        - /etc/azkaban/azkaban-submit-job


### PR DESCRIPTION
Try 2 of camus at shopify (long live albert?, I wish we called it king then I could say long live the king)

The following are changes that are included in this PR:
- Camus shopify module
- \- Builds a shaded jar for use in production
- \- Shopify data partitioner to make the transition process to albert easy peasy
- Circle and Shipit support
- Compiled with CDH libraries to run on shopify cluster

What we do not support yet:
Camus sweeper to get around small file problem (Upstream and my branch have significantly diverged and they are refactoring it too. I'm in touch with maintainers to get most of my changes in). We will support this soon enough.

Please review 
@drdee @airhorns
cc @Shopify/data-engineers 
cc @wvanbergen @snormore @eapache 
