### PR TITLE
CDH 4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,17 +78,17 @@
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>2.0.0-mr1-cdh4.4.0</version>
+				<version>2.0.0-mr1-cdh4.7.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-core</artifactId>
-				<version>2.0.0-mr1-cdh4.4.0</version>
+				<version>2.0.0-mr1-cdh4.7.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-common</artifactId>
-				<version>2.0.0-cdh4.4.0</version>
+				<version>2.0.0-cdh4.7.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
To be deployed after tomorrow's CDH 4.7.x upgrade

Upgrade to Hadoop-: 

Client 4.7.1:
https://repository.cloudera.com/artifactory/cloudera-repos/org/apache/hadoop/hadoop-client/2.0.0-mr1-cdh4.7.1/

Core 4.7.1:
https://repository.cloudera.com/artifactory/cloudera-repos/org/apache/hadoop/hadoop-core/2.0.0-mr1-cdh4.7.1/

Common 4.7.1:
https://repository.cloudera.com/artifactory/cloudera-repos/org/apache/hadoop/hadoop-common/2.0.0-cdh4.7.1/

Not really sure how to verify this works, but I did successfully `mvn install` and `mvn clean package` on my machine.

@yagnik @airhorns 
