### PR TITLE
Upgrade camus to cdh 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,17 +78,17 @@
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>2.0.0-mr1-cdh4.7.0</version>
+				<version>2.5.0-mr1-cdh5.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-core</artifactId>
-				<version>2.0.0-mr1-cdh4.7.0</version>
+				<version>2.5.0-mr1-cdh5.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-common</artifactId>
-				<version>2.0.0-cdh4.7.0</version>
+				<version>2.5.0-cdh5.2.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Upgraded Camus to cdh 5.2.0 with mr1 libraries for https://github.com/Shopify/data-disruptions/issues/22

cc @Shopify/data-engineers 
