### PR TITLE
Log delay from camus

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -9,14 +9,19 @@ import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.CounterGroup;
 import org.apache.hadoop.util.ToolRunner;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import com.linkedin.camus.coders.CamusWrapper;
 
 import com.linkedin.camus.etl.kafka.reporter.TimeReporter;
+
 
 public class StatsdReporter extends TimeReporter {
 
     public static final String STATSD_ENABLED = "statsd.enabled";
     public static final String STATSD_HOST = "statsd.host";
     public static final String STATSD_PORT = "statsd.port";
+    public static final String PREFIX = "Camus";
 
     private static boolean statsdEnabled;
     private static StatsDClient statsd;
@@ -28,9 +33,9 @@ public class StatsdReporter extends TimeReporter {
 
     private void submitCountersToStatsd(Job job) throws IOException {
         Counters counters = job.getCounters();
-        if (getStatsdEnabled(job)) {
+        if (getStatsdEnabled(job.getConfiguration())) {
             StatsDClient statsd = new NonBlockingStatsDClient(
-                "Camus", getStatsdHost(job), getStatsdPort(job), new String[]{"camus:counters"}
+                PREFIX, getStatsdHost(job.getConfiguration()), getStatsdPort(job.getConfiguration()), new String[]{"camus:counters"}
             );
             for (CounterGroup counterGroup: counters) {
                 for (Counter counter: counterGroup){
@@ -40,15 +45,28 @@ public class StatsdReporter extends TimeReporter {
         }
     }
 
-    public static Boolean getStatsdEnabled(Job job) {
-        return job.getConfiguration().getBoolean(STATSD_ENABLED, false);
+    public static void logEventDelay(JobContext context, String topic, CamusWrapper wrap) {
+        if (getStatsdEnabled(context.getConfiguration())) {
+            long currentTime = System.currentTimeMillis();
+            long delay = currentTime - wrap.getTimestamp();
+            if ( delay >= 3600000 ) {
+                statsd = new NonBlockingStatsDClient(
+                    PREFIX, getStatsdHost(context.getConfiguration()), getStatsdPort(context.getConfiguration()), new String[]{"topic:" + topic}
+                );
+                statsd.gauge("load_delay", delay);
+            }
+        }
     }
 
-    public static String getStatsdHost(Job job) {
-        return job.getConfiguration().get(STATSD_HOST, "localhost");
+    public static Boolean getStatsdEnabled(Configuration config) {
+        return config.getBoolean(STATSD_ENABLED, false);
     }
 
-    public static int getStatsdPort(Job job) {
-        return job.getConfiguration().getInt(STATSD_PORT, 8125);
+    public static String getStatsdHost(Configuration config) {
+        return config.get(STATSD_HOST, "localhost");
+    }
+
+    public static int getStatsdPort(Configuration config) {
+        return config.getInt(STATSD_PORT, 8125);
     }
 }


### PR DESCRIPTION
This will log delay to :dog: if it is over 1 hour from load time. It will allow us to see which topics are regularly late and we can then dig into why.

I'm already re-writing reporting module for camus for confluent so I don't plan to move this upstream to linkedin. 

@drdee @kmtaylor-github 
cc @Shopify/data-engineers 
