### PR TITLE
Deploy to oozie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ camus.zip
 
 # decrypted azkaban secrets
 camus-shopify/azkaban.json
+camus-shopify/oozie.json

--- a/camus-shopify/oozie.ejson
+++ b/camus-shopify/oozie.ejson
@@ -1,0 +1,8 @@
+{
+  "_public_key": "8bff0a932744632a51fdfe0f56a0bec4f381b83b27b04fdf7a551ffd06ab527a",
+  "webhdfs": "EJ[1:wjSQ6//3LrtqcjS5vrgJ33KTcEw9l/NpWiHfFWx1vmI=:2iar8JXuwnRNsNrZqp+RY46WvtYuKbGp:1ZBvSiVUbWeYcODhqXFtYk/LcynkqTSgrg8fQb6vfUOwjFyCc2SlbRJ8Bw==]",
+  "jobtracker": "EJ[1:wjSQ6//3LrtqcjS5vrgJ33KTcEw9l/NpWiHfFWx1vmI=:fRc4cf8JooZ/3OT/xaxXkdQl+XjAl+pH:dBJLvRbDF+2nv0d0I/pvSUnUmqOPJPMIzlU+Kb9rd4cbIEP0PkugQSQpM2XI0w==]",
+  "namenode": "EJ[1:wjSQ6//3LrtqcjS5vrgJ33KTcEw9l/NpWiHfFWx1vmI=:85BE6mI06L+nQyauz0Dnh4KOEzWzXz+L:iM1n6F4WJS96ZN0sHNtA+bfBaJSIrVIgNnI0lB51T94jArtpcJIGUz00folt]",
+  "hadoop_production": "EJ[1:wjSQ6//3LrtqcjS5vrgJ33KTcEw9l/NpWiHfFWx1vmI=:kxAgD59pKawqU65bia0zRdvydo4mYNb4:soKvxnva43WlRYQ2LE/Yo5sQa20HHT4ftRYhVACEZqLP]",
+  "oozie_url": "EJ[1:wjSQ6//3LrtqcjS5vrgJ33KTcEw9l/NpWiHfFWx1vmI=:klx6v05vn9E9oOSvvD9H22evn4baZOT2:KS8GxMY7opODeEoOdYfHXWGnmnd7nwrVwow3XV+zCVDkuNiwD4KWNHbAEEmpSCUrrqUub8ZMpm9G]"
+}

--- a/camus-shopify/script/deploy
+++ b/camus-shopify/script/deploy
@@ -3,5 +3,4 @@ set -e
 source .venv/bin/activate
 pip install Fabric==1.10.1
 pip install git+git://github.com/orenmazor/oozie.py@78cb35f4e5210412baa7b1dac8c3231242f8bad7
-./camus-shopify/script/upload
 ./camus-shopify/script/update_oozie_schedule

--- a/camus-shopify/script/deploy
+++ b/camus-shopify/script/deploy
@@ -4,5 +4,4 @@ source .venv/bin/activate
 pip install Fabric==1.10.1
 pip install git+git://github.com/orenmazor/oozie.py@78cb35f4e5210412baa7b1dac8c3231242f8bad7
 ./camus-shopify/script/upload
-./camus-shopify/script/update_schedule
 ./camus-shopify/script/update_oozie_schedule

--- a/camus-shopify/script/deploy
+++ b/camus-shopify/script/deploy
@@ -2,5 +2,7 @@
 set -e
 source .venv/bin/activate
 pip install Fabric==1.10.1
+pip install git+git://github.com/orenmazor/oozie.py@78cb35f4e5210412baa7b1dac8c3231242f8bad7
 ./camus-shopify/script/upload
 ./camus-shopify/script/update_schedule
+./camus-shopify/script/update_oozie_schedule

--- a/camus-shopify/script/update_oozie_schedule
+++ b/camus-shopify/script/update_oozie_schedule
@@ -37,18 +37,18 @@ def get_camus_version(path):
 
 
 def main():
-    oozie = oozie_server.OozieServer('http://hadoop-misc4.chi.shopify.com:11000')
+    secrets = json.load(open(os.path.join(os.getcwd(), 'camus-shopify', 'oozie.json')))
+    oozie = oozie_server.OozieServer(secrets['oozie_url'])
 
     command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://hadoop-rm.chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
     command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
     command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
     command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
 
-    #TODO change the email to camus@shopify.pagerduty.com
-    os.environ['WEBHDFS_HOST'] = 'hadoop-misc.chi.shopify.com'
-    os.environ['JOBTRACKER'] = 'hadoop-rm.chi.shopify.com:8032'
-    os.environ['NAMENODE'] = 'hdfs://hadoop-production:8020'
-    os.environ['HADOOP_PRODUCTION'] = 'hadoop-production'
+    os.environ['WEBHDFS_HOST'] = secrets['webhdfs']
+    os.environ['JOBTRACKER'] = secrets['jobtracker']
+    os.environ['NAMENODE'] = secrets['namenode']
+    os.environ['HADOOP_PRODUCTION'] = secrets['hadoop_production']
 
     # the workflow is the actual job runner
     oozie_wf = workflow.Workflow("Camus", "oren.mazor@shopify.com", path="user/oozie/workflows/")

--- a/camus-shopify/script/update_oozie_schedule
+++ b/camus-shopify/script/update_oozie_schedule
@@ -42,7 +42,7 @@ def main():
 
     command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://hadoop-rm.chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
     command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
-    command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
+    command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus '
     command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
 
     os.environ['WEBHDFS_HOST'] = secrets['webhdfs']

--- a/camus-shopify/script/update_oozie_schedule
+++ b/camus-shopify/script/update_oozie_schedule
@@ -43,7 +43,7 @@ def main():
     command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://hadoop-rm.chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
     command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
     command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus '
-    command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
+    command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus-oozie.properties"'
 
     os.environ['WEBHDFS_HOST'] = secrets['webhdfs']
     os.environ['JOBTRACKER'] = secrets['jobtracker']

--- a/camus-shopify/script/update_oozie_schedule
+++ b/camus-shopify/script/update_oozie_schedule
@@ -39,8 +39,8 @@ def get_camus_version(path):
 def main():
     oozie = oozie_server.OozieServer('http://hadoop-misc4.chi.shopify.com:11000')
 
-    command = 'bash -c "java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy '
-    command += '-Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
+    command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://hadoop-rm.chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
+    command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
     command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
     command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
 

--- a/camus-shopify/script/update_oozie_schedule
+++ b/camus-shopify/script/update_oozie_schedule
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import os
+import sys
+import json
+import subprocess
+import logging as lg
+from datetime import datetime
+
+from oozie import oozie_server, workflow, coordinators, bundle, actions
+
+formatter = lg.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s', '%d/%m/%y %H:%M:%S')
+ch = lg.StreamHandler(sys.stdout)
+ch.setFormatter(formatter)
+logger = lg.getLogger('oozie_submit_job')
+logger.setLevel(lg.INFO)
+logger.addHandler(ch)
+
+
+def run_shell_command(cmd, description, cwd=None, shell=False):
+    if not cwd:
+        cwd = os.getcwd()
+    p = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, shell=shell)
+    stdout, stderr = p.communicate()
+    logger.info('%s: %s' % (description, stdout))
+    if stderr:
+        logger.error(stderr)
+        exit(-1)
+    else:
+        return stdout.strip()
+
+
+def get_camus_version(path):
+    path = os.path.join(path, 'camus-shopify')
+    logger.info('Retrieving Camus version from %s' % path)
+    cmd = "mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'"
+    return run_shell_command(cmd, 'Retrieved Camus version', path, True)
+
+
+def main():
+    oozie = oozie_server.OozieServer('http://hadoop-misc4.chi.shopify.com:11000')
+
+    command = 'bash -c "java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy '
+    command += '-Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
+    command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
+    command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
+
+    #TODO change the email to camus@shopify.pagerduty.com
+    os.environ['WEBHDFS_HOST'] = 'hadoop-misc.chi.shopify.com'
+    os.environ['JOBTRACKER'] = 'hadoop-rm.chi.shopify.com:8032'
+    os.environ['NAMENODE'] = 'hdfs://hadoop-production:8020'
+    os.environ['HADOOP_PRODUCTION'] = 'hadoop-production'
+
+    # the workflow is the actual job runner
+    oozie_wf = workflow.Workflow("Camus", "oren.mazor@shopify.com", path="user/oozie/workflows/")
+    camus_build = actions.ShellAction(name="CamusBuild", command="ssh", args=['azkaban@hadoop-misc4.chi.shopify.com', command], env=[]) 
+    oozie_wf.add(camus_build)
+    oozie_wf.save()
+
+    # the coordinator handles the schedule
+    starttime = datetime.now().strftime("%Y-%m-%dT%H:%MZ")
+    coordinator = coordinators.Coordinator("Camus", oozie_wf, 60 * 60, starttime)
+    coordinator.save()
+
+    # the bundle is pretty in an OCD kind of way
+    bun = bundle.Bundle("Camus")
+    bun.add(coordinator)
+    bun.save()
+
+    # if the bundle is already in existence, do not submit a new one
+    # NOTE: if we start adding new coordinators to this bundle, there will be a bug
+    # in the fact we cannot automatically reload a bundle it has to be manual.
+    # the scrappy fix is to delete the existing Camus bundle and just re-deploy.
+    if bun.name not in [b['bundleJobName'] for b in oozie.bundles('RUNNING')]:
+        oozie.submit(bun)
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# What

this _moves_ camus over to azkaban. once you ship this, the camus bundle will immediately start running. be aware, unlike me (sorry again, @yagnik and @drdee)
# How

using oozie.py, the same way that starscream runs it. this ssh's into hadoop-misc4 and executes the same command that azkaban does.
# Where

example bundle: https://hue.data.shopify.com/oozie/list_oozie_bundle/0000285-150806185006694-oozie-oozi-B
