### PR TITLE
Add camus watermark

### DIFF
--- a/camus-shopify/LICENSE.md
+++ b/camus-shopify/LICENSE.md
@@ -1,0 +1,7 @@
+## camus-shopify files under the `org.wikimedia.analytics.refinery` namespace
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/camus-shopify/pom.xml
+++ b/camus-shopify/pom.xml
@@ -32,6 +32,36 @@
             <version>0.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_2.10</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.scopt</groupId>
+            <artifactId>scopt_2.10</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.10</artifactId>
+            <version>2.2.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -63,6 +93,20 @@
                                 </excludes>
                             </artifactSet>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/camus-shopify/script/update_schedule
+++ b/camus-shopify/script/update_schedule
@@ -48,16 +48,27 @@ def main():
     camus_jar = get_camus_version(repo_root)
     azkaban_auth = json.load(open(os.path.join(repo_root, 'camus-shopify', 'azkaban.json')))
 
-    command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://resource-manager1.hu131.data-chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
-    command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
-    command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
-    command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
+    camus_command = 'bash -c "curl --compressed -H \'Accept: application/json\' -X GET \'http://resource-manager1.hu131.data-chi.shopify.com:8088/ws/v1/cluster/apps?states=RUNNING,ACCEPTED\' | grep -v Camus && echo \'Camus is not running\' && '
+    camus_command += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
+    camus_command += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
+    camus_command += 'com.linkedin.camus.etl.kafka.CamusJob -P /u/apps/camus/shared/camus.properties"'
+
+    camus_watermark_cmd = 'bash -c "'
+    camus_watermark_cmd += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/camus/shared/log4j.xml '
+    camus_watermark_cmd += '-cp $(hadoop classpath):/u/apps/camus/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
+    camus_watermark_cmd += 'org.wikimedia.analytics.refinery.job.CamusPartitionChecker -c /u/apps/camus/shared/camus.properties"'
 
     project = Project('Camus')
-    project.add_job('Camus', Job({'failure.emails': 'camus@shopify.pagerduty.com',
+    project.add_job('Camus Import', Job({'failure.emails': 'camus@shopify.pagerduty.com',
                                   'type': 'command',
-                                  'command': command
-    }))
+                                  'command': camus_command
+                                  }))
+    project.add_job("Camus Watermark", Job({'failure.emails': 'camus@shopify.pagerduty.com',
+                                            'type': 'command',
+                                            'command': camus_watermark_cmd,
+                                            'dependencies': 'Camus Import'}
+                                           ))
+    project.add_job("Camus", Job({'dependencies': 'Camus Watermark', 'type':'noop'}))
 
     logger.info('Building zip file')
     project.build('camus.zip', True)

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
@@ -1,0 +1,241 @@
+package org.wikimedia.analytics.refinery.job
+
+import java.io.FileInputStream
+import java.util.Properties
+
+import com.linkedin.camus.etl.kafka.CamusJob
+import com.linkedin.camus.etl.kafka.common.EtlKey
+import com.linkedin.camus.etl.kafka.mapred.{EtlInputFormat, EtlMultiOutputFormat}
+import org.apache.commons.lang.StringUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.log4j.{LogManager, Logger}
+import org.joda.time.{Hours, DateTimeZone, DateTime}
+import scopt.OptionParser
+import com.github.nscala_time.time.Imports._
+
+/**
+ * Class marking checking camus runs based on a camus.properties file.
+ * It flags hdfs imported data for fully imported hours.
+ *
+ * command example (replace [*] with * in classpath - hack to prevent scala comment issue):
+ * java -Dlog4j.configuration=file:///home/joal/code/log4j_console.properties \
+ *      -cp "/home/joal/code/analytics-refinery-source/refinery-job/target/refinery-job-0.0.21-SNAPSHOT.jar:/usr/lib/spark/lib/[*]:/usr/lib/hadoop/[*]:/usr/lib/hadoop-hdfs/[*]:/usr/lib/hadoop/lib/[*]:/usr/share/java/[*]" \
+ *      org.wikimedia.analytics.refinery.job.CamusPartitionChecker -c /home/joal/camus.test.import.properties
+ *
+ */
+object CamusPartitionChecker {
+
+  val BLACKLIST_TOPICS = EtlInputFormat.KAFKA_BLACKLIST_TOPIC
+  val WHITELIST_TOPICS = EtlInputFormat.KAFKA_WHITELIST_TOPIC
+  val PARTITION_BASE_PATH = EtlMultiOutputFormat.ETL_DESTINATION_PATH
+  val EARLIEST_OF_TIMES = 1388534400000L // Jan 1, 2014
+
+
+  // Dummy values, to be set with configuration in main
+  var fs: FileSystem = FileSystem.get(new Configuration)
+  var camusReader: CamusStatusReader = new CamusStatusReader(fs)
+  val props: Properties = new Properties
+  val log: Logger = Logger.getLogger(CamusPartitionChecker.getClass)
+
+  /**
+   * Computes calendar hours happening between two timestamps. For instance
+   * if  t1 =  = 2015-09-25 03:28:12
+   * and t2 =  = 2015-09-25 06:55:32
+   * Returned result is
+   *     [(2015, 9, 25, 4), (2015, 9, 25, 5),(2015, 9, 25, 6)]
+   * @param t1 The first timestamp (oldest)
+   * @param t2 The second timestamp (youngest)
+   * @return the hours having happened between t1 and t2 in format (year, month, day, hour)
+   */
+  def finishedHoursInBetween(t1: Long, t2: Long): Seq[(Int, Int, Int, Int)] = {
+    val oldestNextHour = new DateTime(t1 , DateTimeZone.UTC).hourOfDay.roundCeilingCopy
+    val youngestPreviousHour = new DateTime(t2, DateTimeZone.UTC).hourOfDay.roundFloorCopy
+    for (h <- 0 to Hours.hoursBetween(oldestNextHour, youngestPreviousHour).getHours ) yield {
+      val fullHour: DateTime = oldestNextHour + h.hours - 1.hours
+      (fullHour.year.get, fullHour.monthOfYear.get, fullHour.dayOfMonth.get, fullHour.hourOfDay.get)
+    }
+  }
+
+  def partitionDirectory(base: String, topic: String, year: Int, month: Int, day: Int, hour: Int): String = {
+    if ((! StringUtils.isEmpty(base)) && (! StringUtils.isEmpty(topic)))
+      f"${base}%s/${topic}%s/${year}%04d/${month}%02d/${day}%02d/${hour}%02d"
+    else
+      throw new IllegalArgumentException("Can't make partition directory with empty base or topic.")
+  }
+
+  /** Compute complete hours imported on a camus run by topic. Throws an IllegalStateException if
+    * the camus run state is not correct (missing topics or import-time not moving)
+    * @param camusRunPath the camus run Path folder to use
+    * @return a map of topic -> Seq[(year, month, day, hour)]
+    */
+  def getTopicsAndHoursToFlag(camusRunPath: Path, backfill: Boolean = false): Map[String, Seq[(Int, Int, Int, Int)]] = {
+    // Empty Whitelist means all --> default to .* regexp
+    val topicsWhitelist = "(" + props.getProperty(WHITELIST_TOPICS, ".*").replaceAll(" *, *", "|") + ")"
+    // Empty Blacklist means no blacklist --> Default to empty string
+    val topicsBlacklist = "(" + props.getProperty(BLACKLIST_TOPICS, "").replaceAll(" *, *", "|") + ")"
+
+    val currentOffsets: Seq[EtlKey] = camusReader.readEtlKeys(camusReader.offsetsFiles(camusRunPath))
+    val previousOffsets: Seq[EtlKey] = camusReader.readEtlKeys(camusReader.previousOffsetsFiles(camusRunPath))
+
+    val currentTopicsAndOldestTimes = camusReader.topicsAndOldestTimes(currentOffsets)
+    val previousTopicsAndOldestTimes = if (backfill) {
+      log.info(s"Running backfill version, updating folders since the 'beggining of times': $EARLIEST_OF_TIMES")
+      currentTopicsAndOldestTimes.mapValues[Long]((currentTime) => EARLIEST_OF_TIMES)
+    } else {
+      camusReader.topicsAndOldestTimes(previousOffsets)
+    }
+
+    val finalMap = previousTopicsAndOldestTimes.foldLeft(Map.empty[String, Seq[(Int, Int, Int, Int)]])(
+      (map, previousTopicAndTime) => {
+        var returnMap = map
+        val (previousTopic, previousTime) = previousTopicAndTime
+        if ((! previousTopic.matches(topicsBlacklist)) && previousTopic.matches(topicsWhitelist)) {
+          if (currentTopicsAndOldestTimes.contains(previousTopic) && (currentTopicsAndOldestTimes.get(previousTopic).get > previousTime)) {
+            val hours = finishedHoursInBetween(previousTime, currentTopicsAndOldestTimes.get(previousTopic).get)
+            returnMap = map + (previousTopic -> hours)
+          } else
+            log.info(s"Topic $previousTopic has no new data")
+        }
+        returnMap
+      }
+    )
+    finalMap
+  }
+
+  def flagFullyImportedPartitions(flag: String,
+                                  dryRun: Boolean,
+                                  topicsAndHours: Map[String, Seq[(Int, Int, Int, Int)]]): Unit = {
+    for ((topic, hours) <- topicsAndHours) {
+      for ((year, month, day, hour) <- hours) {
+        val dir = partitionDirectory(
+          props.getProperty(PARTITION_BASE_PATH), topic, year, month, day, hour)
+        val partitionPath: Path = new Path(dir)
+        if (fs.exists(partitionPath) && fs.isDirectory(partitionPath)) {
+          val flagPath = new Path(s"${dir}/${flag}")
+          if (! dryRun) {
+            fs.create(flagPath)
+            log.info(s"Flag created: ${dir}/${flag}")
+          } else
+            log.info(s"DryRun - Flag would have been created: ${dir}/${flag}")
+        } else
+          log.warn(s"Couldn't find $topic folder in $partitionPath. Can't flag it.")
+      }
+    }
+  }
+
+  case class Params(camusPropertiesFilePath: String = "",
+                    datetimeToCheck: Option[String] = None,
+                    hadoopCoreSitePath: String = "/etc/hadoop/conf/core-site.xml",
+                    hadoopHdfsSitePath: String = "/etc/hadoop/conf/hdfs-site.xml",
+                    flag: String = "_IMPORTED",
+                    dryRun: Boolean = false,
+                    backfill: Boolean = false)
+
+  val argsParser = new OptionParser[Params]("Camus Checker") {
+    head("Camus partition checker", "")
+    note(
+      "This job checked for most recent camus run correctness and flag hour partitions when fully imported.")
+    help("help") text ("Prints this usage text")
+
+    opt[String]('c', "camus-properties-file") required() valueName ("<path>") action { (x, p) =>
+      p.copy(camusPropertiesFilePath = x)
+    } text ("Camus configuration properties file path.")
+
+    opt[String]('d', "datetimeToCheck") optional() valueName ("yyyy-mm-dd-HH-MM-SS") action { (x, p) =>
+      p.copy(datetimeToCheck = Some(x))
+    } text ("Datetime camus run to check (must be present in history folder) - Default to most recent run.")
+
+    opt[String]("hadoop-core-site-file") optional() valueName ("<path>") action { (x, p) =>
+      p.copy(hadoopCoreSitePath = x)
+    } text ("Hadoop core-site.xml file path for configuration.")
+
+    opt[String]("hadoop-hdfs-site-file") optional() valueName ("<path>") action { (x, p) =>
+      p.copy(hadoopHdfsSitePath = x)
+    } text ("Hadoop hdfs-site.xml file path for configuration.")
+
+    opt[String]("flag") optional() action { (x, p) =>
+      p.copy(flag = x)
+    } validate { f =>
+      if ((! f.isEmpty) && (f.matches("_[a-zA-Z0-9-_]+"))) success else failure("Incorrect flag file name")
+    } text ("Flag file to be used (defaults to '_IMPORTED'.")
+
+    opt[Unit]("dry-run") optional() action { (_, p) =>
+      p.copy(dryRun = true)
+    } text ("Only print check result and if flag files would have been created.")
+
+    opt[Unit]("backfill") optional() action { (_, p) =>
+      p.copy(backfill = true)
+    } text ("Goes through until the 'beggining of times' to flag completed folders.")
+  }
+
+  def isLog4JConfigured():Boolean = {
+    if (Logger.getRootLogger.getAllAppenders.hasMoreElements)
+      return true
+    val loggers = LogManager.getCurrentLoggers
+    while (loggers.hasMoreElements)
+      if (loggers.nextElement.asInstanceOf[Logger].getAllAppenders.hasMoreElements)
+        return true
+    return false
+  }
+
+  def main(args: Array[String]): Unit = {
+    if (! isLog4JConfigured)
+      org.apache.log4j.BasicConfigurator.configure
+
+    argsParser.parse(args, Params()) match {
+      case Some (params) => {
+        try {
+          log.info("Loading hadoop configuration.")
+          val conf: Configuration = new Configuration()
+          conf.addResource(new Path(params.hadoopCoreSitePath))
+          conf.addResource(new Path(params.hadoopHdfsSitePath))
+          fs = FileSystem.get(conf)
+          camusReader = new CamusStatusReader(fs)
+
+          log.info("Loading camus properties file.")
+          props.load(new FileInputStream(params.camusPropertiesFilePath))
+
+          val camusPathToCheck: Path = {
+            val history_folder = props.getProperty(CamusJob.ETL_EXECUTION_HISTORY_PATH)
+            if (params.datetimeToCheck.isEmpty) {
+              log.info("Getting camus most recent run from history folder.")
+              camusReader.mostRecentRun(new Path(history_folder))
+            } else {
+              val p = new Path(props.getProperty(CamusJob.ETL_EXECUTION_HISTORY_PATH) + "/" + params.datetimeToCheck.get)
+              if (fs.isDirectory(p)) {
+                log.info("Set job to given datetime to check.")
+                p
+              } else {
+                log.error("The given datetime to check is not a folder in camus history.")
+                null
+              }
+            }
+          }
+          if (null == camusPathToCheck)
+            System.exit(1)
+
+          log.info("Checking job correctness and computing partitions to flag as imported.")
+          val topicsAndHours = getTopicsAndHoursToFlag(camusPathToCheck, params.backfill)
+
+          log.info("Job is correct, flag imported partitions.")
+          flagFullyImportedPartitions(params.flag, params.dryRun, topicsAndHours)
+
+          log.info("Done.")
+        } catch {
+          case e: Exception => {
+            log.error("An error occured during execution.", e)
+            sys.exit(1)
+          }
+        }
+      }
+      case None => {
+        log.error("No parameter passed. Please run with --help to see options.")
+        sys.exit(1)
+      }
+    }
+
+  }
+
+
+}

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
@@ -70,8 +70,11 @@ object CamusPartitionChecker {
     * @return a map of topic -> Seq[(year, month, day, hour)]
     */
   def getTopicsAndHoursToFlag(camusRunPath: Path, backfill: Boolean = false): Map[String, Seq[(Int, Int, Int, Int)]] = {
+    var whitelist = props.getProperty(WHITELIST_TOPICS, ".*")
+    if (whitelist.isEmpty) whitelist = ".*"
+
     // Empty Whitelist means all --> default to .* regexp
-    val topicsWhitelist = "(" + props.getProperty(WHITELIST_TOPICS, ".*").replaceAll(" *, *", "|") + ")"
+    val topicsWhitelist = "(" + whitelist.replaceAll(" *, *", "|") + ")"
     // Empty Blacklist means no blacklist --> Default to empty string
     val topicsBlacklist = "(" + props.getProperty(BLACKLIST_TOPICS, "").replaceAll(" *, *", "|") + ")"
 

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
@@ -15,15 +15,18 @@ import scopt.OptionParser
 import com.github.nscala_time.time.Imports._
 
 /**
- * Class marking checking camus runs based on a camus.properties file.
- * It flags hdfs imported data for fully imported hours.
- *
- * command example (replace [*] with * in classpath - hack to prevent scala comment issue):
- * java -Dlog4j.configuration=file:///home/joal/code/log4j_console.properties \
- *      -cp "/home/joal/code/analytics-refinery-source/refinery-job/target/refinery-job-0.0.21-SNAPSHOT.jar:/usr/lib/spark/lib/[*]:/usr/lib/hadoop/[*]:/usr/lib/hadoop-hdfs/[*]:/usr/lib/hadoop/lib/[*]:/usr/share/java/[*]" \
- *      org.wikimedia.analytics.refinery.job.CamusPartitionChecker -c /home/joal/camus.test.import.properties
- *
- */
+  *
+  * This is a modified version of the original class found in https://github.com/wikimedia/analytics-refinery-source
+  * whose original author is Joseph Allemandou <joal@wikimedia.org>
+  *
+  * Class marking checking camus runs based on a camus.properties file.
+  * It flags hdfs imported data for fully imported hours.
+  *
+  * command example (replace [*] with * in classpath - hack to prevent scala comment issue):
+  * java -Dlog4j.configuration=file:///home/joal/code/log4j_console.properties \
+  *      -cp "/home/joal/code/analytics-refinery-source/refinery-job/target/refinery-job-0.0.21-SNAPSHOT.jar:/usr/lib/spark/lib/[*]:/usr/lib/hadoop/[*]:/usr/lib/hadoop-hdfs/[*]:/usr/lib/hadoop/lib/[*]:/usr/share/java/[*]" \
+  *      org.wikimedia.analytics.refinery.job.CamusPartitionChecker -c /home/joal/camus.test.import.properties
+  */
 object CamusPartitionChecker {
 
   val BLACKLIST_TOPICS = EtlInputFormat.KAFKA_BLACKLIST_TOPIC

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
@@ -1,0 +1,83 @@
+package org.wikimedia.analytics.refinery.job
+
+import com.linkedin.camus.etl.kafka.common.EtlKey
+import org.apache.hadoop.fs._
+import org.apache.hadoop.io.{NullWritable, SequenceFile, Writable, WritableComparable}
+
+
+
+class CamusStatusReader(fs: FileSystem) {
+
+  /**
+   * Reads EtlKeys from a sequence file
+   * @param path the Path of the sequence file
+   * @return the read EtlKey sequence
+   */
+  def readEtlKeys(path: Path): Seq[EtlKey] = {
+    val reader = new SequenceFile.Reader(fs, path, fs.getConf)
+    val key: WritableComparable[_] = reader.getKeyClass.newInstance.asInstanceOf[WritableComparable[_]]
+    val value: Writable = NullWritable.get
+    // Would have liked to be fully functionnal ...
+    // But nexct function doesn't really allow
+    var keys = Seq.empty[EtlKey]
+    while (reader.next(key, value)) {
+        keys :+= new EtlKey(key.asInstanceOf[EtlKey])
+    }
+    reader.close
+    keys
+  }
+
+  /**
+   * Reads EtlKeys from multiple sequence files, grouping results in a sequence.
+   * @param paths the sequence of Paths of the sequence files
+   * @return the read EtlKey sequence
+   */
+  def readEtlKeys(paths: Seq[Path]): Seq[EtlKey] = paths.flatMap(this.readEtlKeys(_))
+
+  /**
+   * Private class to easily filter when listing files in folders
+   * @param regexp
+   */
+  private class RegexpPathFilter(regexp: String) extends PathFilter {
+    override def accept(path: Path): Boolean = path.getName matches regexp
+  }
+
+  /**
+   * Finds offsets files in a camus-run folder.
+   * @param path the path to scan for files
+   * @return a list of offset-m-XXXXX paths
+   */
+  def offsetsFiles(path: Path): Seq[Path] = fs.listStatus(path, new RegexpPathFilter("offsets-m-[0-9]{5}")).map(_.getPath)
+
+  /**
+   * Finds previous offsets files in a camus-run folder.
+   * @param path the path to scan for files
+   * @return a list of offsetprevious paths (should contain only 1 element)
+   */
+  def previousOffsetsFiles(path: Path): Seq[Path] = fs.listStatus(path, new RegexpPathFilter("offsets-previous")).map(_.getPath)
+
+  def topicsAndOldestTimes(keys: Seq[EtlKey]): Map[String, Long] = {
+    keys.foldLeft (Map.empty[String, Long]) ((map, k) => {
+        if ((! map.contains(k.getTopic)) || (map.get(k.getTopic).get > k.getTime))
+          map + (k.getTopic -> k.getTime)
+        else
+          map
+      })
+  }
+
+  /**
+   * Finds the most recent run in a camus-history folder
+   * @return the most recent run path
+   */
+  def mostRecentRun(path: Path): Path = {
+      // Filter folders with format YYYY-MM-DD-HH-MM-SS
+      // Sort folders by name DESC
+      val executions = fs.listStatus(path, new RegexpPathFilter("[0-9]{4}(-[0-9]{2}){5}")).map(_.getPath)
+                         .sortWith((f1, f2) => f1.getName().compareTo(f2.getName()) < 0)
+      if (executions.length > 0)
+        executions(executions.length - 1)
+      else
+        throw new IllegalArgumentException("Given Path is doesn't contain camus-run folders.")
+  }
+
+}

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
@@ -4,8 +4,10 @@ import com.linkedin.camus.etl.kafka.common.EtlKey
 import org.apache.hadoop.fs._
 import org.apache.hadoop.io.{NullWritable, SequenceFile, Writable, WritableComparable}
 
-
-
+/**
+  * This is a modified version of the original class found in https://github.com/wikimedia/analytics-refinery-source
+  * whose original author is Joseph Allemandou <joal@wikimedia.org>
+  */
 class CamusStatusReader(fs: FileSystem) {
 
   /**

--- a/camus-shopify/src/test/scala/org/wikimedia/analytics/refinery/job/TestCamusPartitionChecker.scala
+++ b/camus-shopify/src/test/scala/org/wikimedia/analytics/refinery/job/TestCamusPartitionChecker.scala
@@ -1,0 +1,196 @@
+package org.wikimedia.analytics.refinery.job
+
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+
+import scala.reflect.io.{Directory}
+
+
+class TestCamusPartitionChecker extends FlatSpec with Matchers with BeforeAndAfterEach {
+
+  val camusHistoryTestFolder = "../refinery-camus/src/test/resources/camus-test-data"
+  val failedRunFolder = "2015-08-15-17-52-01"
+  val noHourRunFolder = "2015-09-29-15-20-08"
+  val hourSpanRunFolder = "2015-10-02-08-00-07"
+  val wrongFolder = "wrong-folder"
+  var tmpDir:File = null
+
+  override def beforeEach(): Unit = {
+    CamusPartitionChecker.props.clear()
+  }
+
+  override def afterEach(): Unit = {
+    if (tmpDir != null && tmpDir.exists()) {
+      val d = new Directory(tmpDir)
+      d.deleteRecursively()
+    }
+  }
+
+  "A CamusChecker" should "find hours in between timestamps" in {
+    val t1: Long = 1443428181000L // 2015-09-28T08:16:21  UTC
+    val t2: Long = 1443436242000L // 2015-09-28T10:30:42  UTC
+
+    val hours = CamusPartitionChecker.finishedHoursInBetween(t1, t2)
+    val expectedHours = Seq((2015, 9, 28, 8), (2015, 9, 28, 9))
+    hours should equal (expectedHours)
+  }
+
+  "A CamusChecker" should "find hours no hours in between inversed timestamps" in {
+    val t1: Long = 1443428181000L // 2015-09-28T10:16:21
+    val t2: Long = 1443436242000L // 2015-09-28T12:30:42
+
+    val hoursEmpty = CamusPartitionChecker.finishedHoursInBetween(t2, t1)
+    hoursEmpty should equal (Seq.empty)
+  }
+
+  it should "compute partition directory" in {
+    val base = "/test/base/folder"
+    val topic = "topic"
+    val (year, month, day, hour) = (2015, 9, 28, 1)
+
+    val partitionDir = CamusPartitionChecker.partitionDirectory(base, topic, year, month, day, hour)
+    val expectedDir = "/test/base/folder/topic/hourly/2015/09/28/01"
+
+    partitionDir should equal(expectedDir)
+  }
+
+  it should "fail computing partition directory if no base" in {
+    val base = null
+    val topic = "topic"
+    val (year, month, day, hour) = (2015, 9, 28, 1)
+
+    intercept[IllegalArgumentException] {
+      CamusPartitionChecker.partitionDirectory(base, topic, year, month, day, hour)
+    }
+  }
+
+  it should "fail computing partition directory if no topic" in {
+    val base = "/test/base/folder"
+    val topic = null
+    val (year, month, day, hour) = (2015, 9, 28, 1)
+
+    intercept[IllegalArgumentException] {
+      CamusPartitionChecker.partitionDirectory(base, topic, year, month, day, hour)
+    }
+  }
+
+  it should "get topics and hours in a camus-run folder with whitelist" in {
+    val folder: String = camusHistoryTestFolder + "/" + hourSpanRunFolder
+    val path: Path = new Path(folder)
+
+    // correct Whitelist, no blacklist --> Should work, one topic in historical data needs to be left aside
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.WHITELIST_TOPICS,
+      "webrequest_maps,webrequest_text,webrequest_upload,webrequest_misc")
+
+    val topicsAndHours = CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+
+    topicsAndHours.size should equal (4)
+    // Some topics have hour to flag
+    for ((t, o) <- topicsAndHours)
+      if (! t.equals("webrequest_maps")) o.size should equal (1)
+      else o.size should equal (0)
+  }
+
+  it should "get topics and hours in a camus-run folder with blacklist" in {
+    val folder: String = camusHistoryTestFolder + "/" + hourSpanRunFolder
+    val path: Path = new Path(folder)
+
+    // No whitelist, correct blacklist --> Should work, one topic in historical data needs to be left aside
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.BLACKLIST_TOPICS,
+      ".*_bits,.*_test")
+
+    val topicsAndHours = CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+
+    topicsAndHours.size should equal (5)
+    // Some topics have hour to flag
+    for ((t, o) <- topicsAndHours)
+      if (! t.equals("webrequest_maps")) o.size should equal (1)
+      else o.size should equal (0)
+  }
+
+  it should "fail getting topics and hours in a camus-run folderwith incorrect whitelist" in {
+    val folder: String = camusHistoryTestFolder + "/" + hourSpanRunFolder
+    val path: Path = new Path(folder)
+
+    // everything whitelist and no blacklist (by default)
+    // --> Should fail, one topic in historical data needs to be left aside
+    intercept[IllegalStateException] {
+      CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+    }
+  }
+
+  it should "fail getting topics and hours in a camus-run folder with incorrect blacklist" in {
+    val folder: String = camusHistoryTestFolder + "/" + hourSpanRunFolder
+    val path: Path = new Path(folder)
+
+    // No whitelist, incorrect blacklist
+    // --> Should fail, one topic in historical data needs to be left aside
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.BLACKLIST_TOPICS,
+      ".*_test")
+    intercept[IllegalStateException] {
+      CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+    }
+  }
+
+  it should "get topics and hours in a camus-run folder with whitelist with no hours to flag" in {
+    val folder: String = camusHistoryTestFolder + "/" + noHourRunFolder
+    val path: Path = new Path(folder)
+
+    // correct Whitelist/blacklist config
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.WHITELIST_TOPICS,
+      "webrequest_maps,webrequest_text,webrequest_upload,webrequest_misc")
+
+    val topicsAndHours = CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+
+    topicsAndHours.size should equal (4)
+    // No hours to flag
+    for ((t, o) <- topicsAndHours)
+      o.size should equal (0)
+  }
+
+  it should "doesn't fail getting topics and hours in an error camus-run folder" in {
+    // Original test was checking for failures, this one makes sure it won't fail
+    val folder: String = camusHistoryTestFolder + "/" + failedRunFolder
+    val path: Path = new Path(folder)
+
+    // correct Whitelist/blacklist config
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.WHITELIST_TOPICS,
+      "webrequest_maps,webrequest_text,webrequest_upload,webrequest_misc")
+
+    CamusPartitionChecker.getTopicsAndHoursToFlag(path)
+  }
+
+  it should "write the file flag for a given partition hour" in {
+    tmpDir = Files.createTempDirectory("testcamus").toFile();
+    val partitionFolder = "testtopic/hourly/2015/10/02/08"
+    val d = new Directory(new File(tmpDir, partitionFolder))
+    d.createDirectory()
+
+    d.list shouldBe empty
+
+    // correct partition base path config
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.PARTITION_BASE_PATH, tmpDir.getAbsolutePath())
+
+    CamusPartitionChecker.flagFullyImportedPartitions("_TESTFLAG", false, Map("testtopic" -> Seq((2015, 10, 2, 8))))
+
+    d.list should not be empty
+    d.list.toSeq.map(_.toString()) should contain (tmpDir.getAbsolutePath() + "/testtopic/hourly/2015/10/02/08/_TESTFLAG")
+
+  }
+
+  it should "doesn't fail writing the file flag if the given partition hour folder doesn't exist" in {
+    // Original test was checking for failures, this one makes sure it won't fail
+    tmpDir = Files.createTempDirectory("testcamus").toFile();
+    val partitionFolder = "testtopic/hourly/2015/10/02/08"
+    val d = new Directory (new File(tmpDir, partitionFolder))
+
+    // correct partition base path config
+    CamusPartitionChecker.props.setProperty(CamusPartitionChecker.PARTITION_BASE_PATH, tmpDir.getAbsolutePath())
+
+    CamusPartitionChecker.flagFullyImportedPartitions("_TESTFLAG", false, Map("testtopic" -> Seq((2015, 10, 2, 8))))
+  }
+
+}


### PR DESCRIPTION
## Problem?

By simply looking at the folders and files dropped by Camus we can't really know what's fully processed and what's not. Our solution so far was implementing an arbitrary 3 hour window (relative to now).
## Solution

This adds a second job to the Camus flow that will inspect Camus's execution metadata and tag completed hourly folders with a `_IMPORTED` file. This should be used as a better watermark for our data processing.
## How?

I extract the base code for that from a Wikimedia open source project. I had to change a few things and we decided it was better to extract that and move into our `camus-shopify` instead of having a separate project.
## Follow-up

I'm working on a PR to add this knowledge to *scream.

@drdee @airhorns 
