### PR TITLE
Add script to create Hive partitions for Camus dropped data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target
 *.tar.gz
 *.swp
 *.swo
+*.pyc
 .classpath
 .project
 .settings/

--- a/camus-shopify/script/hive-generic-partitioner.py
+++ b/camus-shopify/script/hive-generic-partitioner.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Automatically adds Hive partitions based on time bucketed HDFS directory hierarchy.
+Usage: hive-partitioner [options] <datadir>
+
+Options:
+    -h --help                           Show this help message and exit.
+    -D --database=<dbname>              Hive database name.  [default: default]
+    -t --tables=<table1[,table2...]>    Tables to create partitions for.  If not specified,
+                                        all directories found in <datadir> will be partitioned.
+    -o --hive-options=<options>         Any valid Hive CLI options you want to pass to Hive commands.
+                                        Example: '--auxpath /path/to/hive-serdes-1.0-SNAPSHOT.jar'
+    -v --verbose                        Turn on verbose debug logging.
+    -n --dry-run                        Don't actually create any partitions, just output the Hive queries to add partitions.
+"""
+__author__ = 'Andrew Otto <otto@wikimedia.org>'
+
+from   datetime import datetime
+from   docopt   import docopt
+import logging
+
+from util import HiveUtils, HdfsDatasetUtils, diff_datewise, interval_hierarchies
+from hive_trekkie import hive_trekkie_create_table_stmt
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    datadir                = arguments['<datadir>']
+    database               = arguments['--database']
+    tables                 = arguments['--tables']
+    hive_options           = arguments['--hive-options']
+    verbose                = arguments['--verbose']
+    dry_run                = arguments['--dry-run']
+
+    log_level = logging.INFO
+    if verbose:
+        log_level = logging.DEBUG
+
+    logging.basicConfig(level=log_level,
+                        format='%(asctime)s %(levelname)-6s %(message)s',
+                        datefmt='%Y-%m-%dT%H:%M:%S')
+
+    if tables:
+        tables = tables.split(',')
+
+    hive = HiveUtils(database, hive_options)
+    for table in tables:
+        table = table.replace('.', '_')
+        if not hive.table_exists(table):
+            if dry_run:
+                logging.info(str(hive_trekkie_create_table_stmt(table)))
+            else:
+                hive.table_create(table)
+
+        if dry_run:
+            logging.info(str(hive.get_missing_partitions_ddl(table)))
+        else:
+            hive.add_missing_partitions(table)
+

--- a/camus-shopify/script/test-util.py
+++ b/camus-shopify/script/test-util.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timedelta
+from util import HiveUtils, HdfsDatasetUtils, diff_datewise, timestamps_to_now, interval_hierarchies
+from unittest import TestCase
+
+
+class TestUtil(TestCase):
+    def test_diff_datewise(self):
+        l = []
+        l_just_dates = []
+        r = []
+        lp = 'blah%Y...%m...%d...%Hblahblah'
+        rp = 'neenee%Y%m%d%Hneenee'
+
+        expect0 = set([datetime(2012, 6, 14, 13), datetime(2012, 11, 9, 3)])
+        expect1 = set([datetime(2012, 6, 14, 14), datetime(2013, 11, 10, 22)])
+
+        for y in range(2012, 2014):
+            for m in range(1, 13):
+                # we're just diffing so we don't care about getting all days
+                for d in range(1, 28):
+                    for h in range(0, 24):
+                        x = datetime(y, m, d, h)
+                        if not x in expect1:
+                            l.append(datetime.strftime(x, lp))
+                            l_just_dates.append(x)
+                        if not x in expect0:
+                            r.append(datetime.strftime(x, rp))
+
+        result = diff_datewise(l, r, left_parse=lp, right_parse=rp)
+        self.assertEqual(result[0], expect0)
+        self.assertEqual(result[1], expect1)
+
+        result = diff_datewise(l_just_dates, r, right_parse=rp)
+        self.assertEqual(result[0], expect0)
+        self.assertEqual(result[1], expect1)
+
+    def test_timestamps_to_now(self):
+        now = datetime.now()
+        start = now - timedelta(hours=2)
+        expect = [
+            start,
+            start + timedelta(hours=1),
+            start + timedelta(hours=2),
+        ]
+        timestamps = timestamps_to_now(start, timedelta(hours=1))
+        self.assertEqual(expect, list(timestamps))
+
+
+class TestHiveUtil(TestCase):
+    def setUp(self):
+        self.hive = HiveUtils()
+        self.hive.tables = {
+            'table1': {
+                'partitions': ['year=2013/month=10/day=01/hour=01', 'year=2013/month=10/day=01/hour=02'],
+                'interval':   'hourly',
+                'depth':      4,
+                'location':   '/path/to/data/table1/hourly',
+            },
+            'table2': {
+                'partitions': ['year=2013/month=10/day=01'],
+                'interval':   'daily',
+                'depth':      3,
+                'location':   '/path/to/data/table2/daily',
+            },
+        }
+
+    def test_table_exists(self):
+        self.assertTrue(self.hive.table_exists('table1'))
+        self.assertFalse(self.hive.table_exists('nonya'))
+
+    def test_partition_ddl(self):
+        d = datetime(2013,10,15,10)
+        for table in self.hive.tables.keys():
+
+            interval = self.hive.tables[table]['interval']
+            expect = 'PARTITION (%s) LOCATION \'%s/%s\'' % (
+                d.strftime(interval_hierarchies[interval]['hive_partition_ddl_format']),
+                self.hive.tables[table]['location'],
+                d.strftime(interval_hierarchies[interval]['directory_format'])
+            )
+            ddl = self.hive.partition_ddl(table, d)
+            self.assertEqual(ddl, expect)
+
+    def test_add_partitions_ddl(self):
+        table = 'table1'
+        interval = 'hourly'
+        ddl_format = interval_hierarchies[interval]['hive_partition_ddl_format']
+        ds = [datetime(2013,10,15,10), datetime(2013,10,15,11)]
+
+
+        expect_ddls = ['PARTITION (%s) LOCATION \'%s/%s\'' % (
+            d.strftime(interval_hierarchies[interval]['hive_partition_ddl_format']),
+            self.hive.tables[table]['location'],
+            d.strftime(interval_hierarchies[interval]['directory_format'])
+        ) for d in ds]
+        expect = '\n'.join(['ALTER TABLE %s ADD %s;' % (table, partition_ddl) for partition_ddl in expect_ddls])
+
+        add_statement = self.hive.add_partitions_ddl(table, ds)
+        self.assertEqual(add_statement, expect)
+
+    def test_create_partitions(self):
+        table = 'table1'
+        ddl_format = interval_hierarchies['hourly']['hive_partition_ddl_format']
+        ds = [datetime(2013,10,15,10), datetime(2013,10,15,11)]
+        expect = "ALTER TABLE table1 ADD\nPARTITION (%s)\nPARTITION (%s);" % (ds[0].strftime(ddl_format), ds[1].strftime(ddl_format))
+
+    def test_partition_interval(self):
+        for t in self.hive.tables.keys():
+            expect = self.hive.tables[t]['interval']
+            self.assertEqual(self.hive.partition_interval(t), expect)
+
+    def table_location(self):
+        self.assertEqual(self.hive.table_location('table1'), self.hive.tables['table1']['location'])
+
+    def test_partition_location(self):
+        interval = 'hourly'
+        d = datetime(2013,10,15,10)
+        expect = self.hive.table_location('table1') + '/' + d.strftime(interval_hierarchies[interval]['directory_format'])
+        self.assertEqual(self.hive.partition_location('table1', d), expect)
+
+
+class TestHdfsDatasetUtils(TestCase):
+    def setUp(self):
+        self.hdfs = HdfsDatasetUtils('/path/to/data')
+
+    def test_dataset_dir(self):
+        self.assertEqual(self.hdfs.dataset_dir('nonya',   'hourly'), '/path/to/data/nonya/hourly')
+        self.assertEqual(self.hdfs.dataset_dir('boogers', 'yearly'), '/path/to/data/boogers/yearly')

--- a/camus-shopify/script/util.py
+++ b/camus-shopify/script/util.py
@@ -1,0 +1,424 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pdb
+import logging
+from datetime import datetime
+import os
+import re
+import subprocess
+import tempfile
+
+from hive_trekkie import hive_trekkie_create_table_stmt
+
+logger = logging.getLogger('camus-hive-partitioner')
+interval_hierarchies = {
+    'hourly':  {
+        'depth':                        4,
+        'directory_format':             '%Y/%m/%d/%H',
+        'hive_partition_format':        'year=%Y/month=%m/day=%d/hour=%H',
+        'hive_partition_ddl_format':    'year=%Y,month=%m,day=%d,hour=%H',
+    },
+    'daily':   {
+        'depth':                        3,
+        'directory_format':             '%Y/%m/%d',
+        'hive_partition_format':        'year=%Y/month=%m/day=%d',
+        'hive_partition_ddl_format':    'year=%Y,month=%m,day=%d',
+    },
+    'monthly': {
+        'depth':                        2,
+        'directory_format':             '%Y/%m',
+        'hive_partition_format':        'year=%Y/month=%m',
+        'hive_partition_ddl_format':    'year=%Y,month=%m',
+   },
+    'yearly':  {
+        'depth':                        1,
+        'directory_format':             '%Y',
+        'hive_partition_format':        'year=%Y',
+        'hive_partition_ddl_format':    'year=%Y',
+    },
+}
+
+
+def diff_datewise(left, right, left_parse=None, right_parse=None):
+    """
+    Parameters
+        left        : a list of datetime strings or objects
+        right       : a list of datetime strings or objects
+        left_parse   : None if left contains datetimes, or strptime format
+        right_parse  : None if right contains datetimes, or strptime format
+
+    Returns
+        A tuple of two sets:
+        [0] : the datetime objects in left but not right
+        [1] : the datetime objects in right but not left
+    """
+
+    if left_parse:
+        left_set = set([
+            datetime.strptime(l.strip(), left_parse)
+            for l in left if len(l.strip())
+        ])
+    else:
+        left_set = set(left)
+
+    if right_parse:
+        right_set = set([
+            datetime.strptime(r.strip(), right_parse)
+            for r in right if len(r.strip())
+        ])
+    else:
+        right_set = set(right)
+
+    return (left_set - right_set, right_set - left_set)
+
+
+def timestamps_to_now(start, increment):
+    """
+    Generates timestamps from @start to datetime.now(), by @increment
+
+    Parameters
+        start       : the first generated timestamp
+        increment   : the timedelta between the generated timestamps
+
+    Returns
+        A generator that goes from @start to datetime.now() - x,
+        where x <= @increment
+    """
+    now = datetime.now()
+    while start < now:
+        yield start
+        start += increment
+
+
+def sh(command, check_return_code=True):
+    """
+    Execute a shell command and return the result.
+    command can be an array or a string.  If it is
+    a string, shell=True will be passed to subprocess.Popen.
+    """
+
+    if isinstance(command, list):
+        shell = False
+        command_string = ' '.join(command)
+    else:
+        shell = True
+        command_string = command
+
+    logger.debug('Running: {0}'.format(command_string))
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
+    stdout, stderr = p.communicate()
+    if check_return_code and p.returncode != 0:
+        raise RuntimeError("Command: {0} failed with error code: {1}".format(command_string, p.returncode),
+                               stdout, stderr)
+    return stdout.strip()
+
+
+class HiveUtils(object):
+    def __init__(self, database='default', options=''):
+        self.database   = database
+        if options:
+            self.options    = options.split()
+        else:
+            self.options = []
+
+        self.hivecmd = ['hive'] + self.options + ['cli', '--database', self.database]
+        self.tables  = {}
+
+    def add_missing_partitions(self, table):
+        add_partition_ddl = self.get_missing_partitions_ddl(table)
+        if (add_partition_ddl and len(add_partition_ddl)>0):
+            self.query(add_partition_ddl)
+
+
+    def get_missing_partitions_ddl(self, table):
+        missing_partitions = self.get_missing_partitions(table) #['orange/2014/08/13', 'orange/2014/08/14']
+        if len(missing_partitions) == 0:
+            return
+
+        partitions_definition = self.get_partitions_definition(table) #['tenant','year','month','day']
+
+        #PARTITION (tenant='orange', year='2014', month='08', day='13') LOCATION 'orange/2014/08/13'
+        #PARTITION (tenant='orange', year='2014', month='08', day='14') LOCATION 'orange/2014/08/14'
+
+        part_ddls = []
+        for mp in missing_partitions:
+            table_hdfs_location = table.replace('_', '.')
+            parts = ','.join(['%s=\'%s\'' % (part, val) for part, val in zip(partitions_definition, mp.split('/'))])
+            part_ddl = "PARTITION (%s) LOCATION '/data/raw/kafka/%s/%s'" % (parts, table_hdfs_location, mp)
+            part_ddls.append(part_ddl)
+
+        return 'ALTER TABLE %s ' % table + 'ADD IF NOT EXISTS ' + ' '.join(part_ddls)
+
+
+    def get_missing_partitions(self, table):
+        msck_cmd = 'MSCK REPAIR TABLE %s ' % table
+        msck_out = self.query(msck_cmd)
+        logging.debug('MSCK REPAIR OUTPUT:\n%s' % msck_out)
+
+        missing_partitions = []
+        for t in msck_out.split('\t'):
+            if table in t:
+                logging.debug('For table %s found missing partition: %s' % (table, t.split(':')[1]))
+                missing_partitions.append(t.split(':')[1])
+
+        return missing_partitions
+
+
+    def get_partitions_definition(self, table):
+        cmd = ' '.join(self.hivecmd) + ' -e \'SHOW CREATE TABLE ' + table + ';\' | sed -n \'/PARTITIONED BY (/,/)/p\' | grep -v \'PARTITIONED BY\' '
+        partitions = sh(cmd).split(',')
+
+        pattern = re.compile('.*`(.+)`', re.MULTILINE)
+        parts = []
+        for pstr in partitions:
+            match = re.search(pattern, pstr)
+            part = match.group(1)
+            parts.append(part)
+
+        return parts
+
+
+    def tables_get(self):
+        """Returns a list of tables in the current database"""
+        t = self.query('SHOW TABLES').split('\n')
+        if 'tab_name' in t:
+          t.remove('tab_name')
+        return t
+
+
+    def tables_init(self):
+        """Initializes the self.tables dict"""
+
+        for table in self.tables_get():
+            self.tables[table] = {}
+
+        return self.tables
+
+
+    def table_exists(self, table): # ,force=False
+        """Returns true if the table exists in the current database."""
+        if not self.tables: self.tables_init()
+
+        return table in self.tables.keys()
+
+
+    def table_create(self, table_name):
+        table_create_stmt = hive_trekkie_create_table_stmt(table_name)
+        self.query(table_create_stmt)
+
+
+    def table_schema(self, table):
+        if not self.tables: self.tables_init()
+
+        if 'schema' not in self.tables[table].keys():
+            cmd = ' '.join(self.hivecmd) + ' -e \'SHOW CREATE TABLE ' + table + ';\' | sed \'1d\''
+            self.tables[table]['schema'] = sh(cmd)
+
+        return self.tables[table]['schema']
+
+
+    def table_location(self, table):
+        if not self.tables: self.tables_init()
+
+        if not 'location' in self.tables[table].keys():
+            location_pattern = re.compile(r"^LOCATION\n\s+'(.+)'\n", re.MULTILINE)
+            match = re.search(location_pattern, self.table_schema(table))
+            location = match.group(1)
+            self.tables[table]['location'] = location
+
+        return self.tables[table]['location']
+
+    def partitions(self, table):
+        """Returns a list of partitions for the given Hive table."""
+        if not self.tables: self.tables_init()
+
+        # cache results for later
+        # if we don't know the partitions yet, get them now
+        if not 'partitions' in self.tables[table].keys():
+            stdout     = self.query("SHOW PARTITIONS %s;" % table)
+            partitions = stdout.split('\n')
+            if 'partition' in partitions:
+              partitions.remove('partition')
+            self.tables[table]['partitions'] = partitions
+
+        return self.tables[table]['partitions']
+
+
+    def create_partitions(self, table, partition_datetimes):
+        """
+        Runs ALTER TABLE table ADD PARTITION ... for each of the partitions
+        defined in the partition_datetimes list.
+        """
+        if partition_datetimes:
+            q = self.add_partitions_ddl(table, partition_datetimes)
+            # This query could be large if there are many partiitons to create.
+            # Use a tempfile when adding partitions.
+            return self.query(q, use_tempfile=True)
+        else:
+            logger.info("Not creating any partitions for table %s.  No partition datetimes were given." % table)
+
+
+    def add_partitions_ddl(self, table, partition_datetimes):
+        """
+        Returns a complete hive statement to add partitions to
+        table for the given datetimes.
+        """
+        ddls = [(self.partition_ddl(table, p)) for p in partition_datetimes]
+        ddls.sort()
+        return '\n'.join(['ALTER TABLE %s ADD %s;' % (table, ddl) for ddl in ddls])
+
+
+    def partition_ddl(self, table, partition_datetime):
+        """
+        Returns a portion of a partition DDL statement.
+        This statement is not enough to add a partition on its own,
+        but may be used as part of a larger ALTER TABLE ADD ... statement.
+        """
+        interval = self.partition_interval(table)
+        return 'PARTITION (%s) LOCATION \'%s\'' % (
+            partition_datetime.strftime(interval_hierarchies[interval]['hive_partition_ddl_format']),
+            self.partition_location(table, partition_datetime)
+        )
+
+    def partition_location(self, table, partition_datetime):
+        interval = self.partition_interval(table)
+        return self.table_location(table) + '/' + partition_datetime.strftime(interval_hierarchies[interval]['directory_format'])
+
+
+    def partition_interval(self, table):
+        """
+        Examines the CREATE TABLE statements for partition layout.
+        Determines the time interval of the partitions based on
+        the number of partition levels.
+        This will cache the interval result in the self.tables dict.
+        """
+
+        if not self.tables: self.tables_init()
+
+        intervals = {
+            4: 'hourly',
+            3: 'daily',
+            2: 'monthly',
+            1: 'yearly',
+        }
+
+        # cache results for later
+        if not 'interval' in self.tables[table].keys():
+
+            # TODO: Use self.table_schema and a regex
+            # rather than running SHOW CREATE TABLE AGAIN!
+
+            # counts the number of partition keys this table has
+            # and returns a string time interval based in this number
+            cmd = ' '.join(self.hivecmd) + ' -e \'SHOW CREATE TABLE ' + table + ';\' | sed -n \'/PARTITIONED BY (/,/)/p\' | grep -v \'PARTITIONED BY\' | wc -l'
+            partition_depth = int(sh(cmd))
+
+            self.tables[table]['depth']    = partition_depth
+            self.tables[table]['interval'] = intervals[partition_depth]
+
+        return self.tables[table]['interval']
+
+    def query(self, query, check_return_code=True, use_tempfile=False):
+        """
+        Runs the given Hive query and returns stdout.
+
+        If use_tempfile is True, the query will be written to
+        a temporary file and run as a Hive script.
+        """
+
+        if use_tempfile:
+            f = tempfile.NamedTemporaryFile(prefix='tmp-hive-query-', suffix='.hiveql')
+            logger.debug('Writing Hive query to tempfile %s.' % f.name)
+            f.write(query)
+            f.flush()
+            out = self.script(f.name)
+            # NamedTemporaryFile will be deleted on close().
+            f.close()
+            return out
+        else:
+            return self.command(['-e', query], check_return_code)
+
+
+    def script(self, script, check_return_code=True):
+        """Runs the contents of the given script in hive and returns stdout."""
+        if not os.path.isfile(script):
+            raise RuntimeError("Hive script: {0} does not exist.".format(script))
+        return self.command( ['-f', script], check_return_code)
+
+
+    def command(self, args, check_return_code=True):
+        """Runs the `hive` from the command line, passing in the given args, and
+           returning stdout.
+        """
+        cmd = self.hivecmd + args
+        return sh(cmd, check_return_code)
+
+
+class HdfsDatasetUtils(object):
+    """
+    Deal with time partitioned data imports in HDFS.
+    Data directory hierarchies must be of the form:
+      <datadir>/<dataset>/<interval>/<year>/<month>/<day>/<hour>.
+
+    <datadir> is the HDFS path of all of your data imports.
+    <dataset> is the name of the dataset inside of <datadir>
+
+    Intervals supported:
+      hourly
+      monthly
+      daily
+      yearly
+
+    The depth of the hierarchy is dependent on the <interval>.
+    E.g. monthly will only be 2 directories deep (<year>/<month>), etc.
+
+    This is useful for identifying time buckets created by Camus,
+    LinkedIn's Kafka -> HDFS import framework.
+    """
+    def __init__(self, datadir):
+        self.datadir = datadir
+
+    def datasets(self):
+        """Reads dataset names out of <datadir>"""
+        return sh(
+            'hdfs dfs -ls {0}/ | '\
+            'grep -v "Found .* items" | '\
+            'awk -F "/" \'{{print $NF}}\''.format(
+                self.datadir
+            )
+        ).split('\n')
+
+    def dataset_dir(self, dataset, interval='hourly'):
+        return (self.datadir + '/' + dataset + '/' + interval)
+
+    # TODO configure interval partition paths automatically instead of hardcoding with time buckets
+    def partitions(self, dataset, interval='hourly'):
+        """
+        Returns a list of time bucketed 'partitions' in HDFS for this dataset.
+        These are inferred from the directory hierarchy in HDFS.
+        """
+
+        basedir = self.dataset_dir(dataset, interval)
+
+        # number of  wildcard time bucket directories, e.g. depth_stars == 4 -> '/*/*/*/*'
+        depth_stars = '/*' * interval_hierarchies[interval]['depth']
+        directories = sh(
+            'hdfs dfs -ls -d {0}{1} | '\
+            'grep -v \'Found .* items\' | '\
+            'awk \'{{print $NF}}\''.format(basedir, depth_stars)
+        ).split('\n')
+
+        # return list of time bucket directories, e.g. ['2013/10/09/15', '2013/10/09/16', ... ]
+        return [directory.replace(basedir + '/', '') for directory in directories]


### PR DESCRIPTION
I took the Python script from https://github.com/wikimedia/kraken/tree/master/kraken-etl and made some adjustments including creating the Hive table if it does not exist and more logging when enabling verbose mode. 

The logic of the script is quite straightforward:
1) Specify a comma separated list of table names (=Trekkie topics) for which you want partitions to be added.
2) If the table does not yet exist, create the table in the Hive metastore. I want to put the file that contains the table schema in Chef and not in this public repo.
3) Then, run `MSCK REPAIR TABLE` to detect for which folders, partitions are missing.
4) Parse that stuff and generate an ALTER TABLE statement that adds those partitions.

@dterror @honkfestival 
