### PR TITLE
Camus replaces _ with . for topic names

### DIFF
--- a/camus-shopify/script/hive-generic-partitioner.py
+++ b/camus-shopify/script/hive-generic-partitioner.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
 
     hive = HiveUtils(database, hive_options)
     for table in tables:
-        hdfs_location = table
+        hdfs_location = table.replace('_', '.')
         table = table.replace('.', '_').replace('-', '_')
         if not hive.table_exists(table):
             if dry_run:


### PR DESCRIPTION
Making the partitioner reflect that. We have a few tables in presto that point to hdfs locations that don't exist. i.e internal_errors

@drdee 