### PR TITLE
add contains_pii tag to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,3 +3,6 @@ director: jduff
 owners:
 - Shopify/data-acquisition
 classification: tier2
+security:
+  data_management:
+    contains_pii: false # Transmits it to data warehouse but doesn't store any


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
We are starting to track the services that contain PII. I'm adding this service to the list of ones we've reviewed.

**How is this accomplished?**
I made a small change to the service.yml to let service-db know that this service **does not** contain pii. This will be done across all services so that we can have better visibility into where our PII is stored.

See Shopify/services-db#868 for a bit more context

**What could go wrong? (if anything)**
Nothing serious. It's a change to the service.yml.

**Rollback steps**
 - [X] It is safe to simply rollback this change

@Shopify/data-acquisition @jduff 
@jenniferross - FYI
