### PR TITLE
Add statsd metrics with topic and patition tags

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlKey.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlKey.java
@@ -330,4 +330,8 @@ public class EtlKey implements WritableComparable<EtlKey>, IEtlKey {
     result = 31 * result + partitionMap.hashCode();
     return result;
   }
-}
+
+  public String statsdTags() {
+    return "topic:" + getTopic() + "," + "partition:" + getPartition();
+  }
+ }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -4,6 +4,8 @@ import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import java.util.Map;
 import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Counters;
@@ -27,12 +29,16 @@ public class StatsdReporter extends TimeReporter {
     submitCountersToStatsd(job);
   }
 
+  private static StatsDClient getClient(Configuration conf) {
+    return new NonBlockingStatsDClient("Camus", getStatsdHost(conf), getStatsdPort(conf),
+            new String[] { "camus:counters" });
+  }
+
   private void submitCountersToStatsd(Job job) throws IOException {
     Counters counters = job.getCounters();
-    if (getStatsdEnabled(job)) {
-      StatsDClient statsd =
-          new NonBlockingStatsDClient("Camus", getStatsdHost(job), getStatsdPort(job),
-              new String[] { "camus:counters" });
+    Configuration conf = job.getConfiguration();
+    if (getStatsdEnabled(conf)) {
+      StatsDClient statsd = getClient(conf);
       for (CounterGroup counterGroup : counters) {
         for (Counter counter : counterGroup) {
           statsd.gauge(counterGroup.getDisplayName() + "." + counter.getDisplayName(), counter.getValue());
@@ -41,15 +47,24 @@ public class StatsdReporter extends TimeReporter {
     }
   }
 
-  public static Boolean getStatsdEnabled(Job job) {
-    return job.getConfiguration().getBoolean(STATSD_ENABLED, false);
+  public static Boolean getStatsdEnabled(Configuration conf) {
+    return conf.getBoolean(STATSD_ENABLED, false);
   }
 
-  public static String getStatsdHost(Job job) {
-    return job.getConfiguration().get(STATSD_HOST, "localhost");
+  public static String getStatsdHost(Configuration conf) {
+    return conf.get(STATSD_HOST, "localhost");
   }
 
-  public static int getStatsdPort(Job job) {
-    return job.getConfiguration().getInt(STATSD_PORT, 8125);
+  public static int getStatsdPort(Configuration conf) {
+    return conf.getInt(STATSD_PORT, 8125);
+  }
+
+  public static void gauge(Configuration conf, String metric, Long value, String... tags) {
+    if (conf.getBoolean(STATSD_ENABLED, false)) {
+      StatsDClient statsd = getClient(conf);
+      System.out.println("Reporting gauge to statsd: metric=" + metric + "; value=" + value.toString() + "; tags=" + String.join(",", tags));
+      statsd.gauge(metric, value, tags);
+    }
+
   }
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -62,9 +62,7 @@ public class StatsdReporter extends TimeReporter {
   public static void gauge(Configuration conf, String metric, Long value, String... tags) {
     if (conf.getBoolean(STATSD_ENABLED, false)) {
       StatsDClient statsd = getClient(conf);
-      System.out.println("Reporting gauge to statsd: metric=" + metric + "; value=" + value.toString() + "; tags=" + String.join(",", tags));
       statsd.gauge(metric, value, tags);
     }
-
   }
 }

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/common/EtlKeyTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/common/EtlKeyTest.java
@@ -78,6 +78,12 @@ public class EtlKeyTest {
     assertFalse(etlKeyA.hashCode() == etlKeyB.hashCode());
   }
 
+  @Test
+  public void testStatsDTags() throws Exception {
+    final EtlKey etlKey = new EtlKey("topic_id", "leader_id", 2);
+    assertEquals(etlKey.statsdTags(), "topic:topic_id,partition:2");
+  }
+
   public static class OldEtlKey implements WritableComparable<OldEtlKey> {
     private String leaderId = "leaderId";
     private int partition = 1;


### PR DESCRIPTION
- count of new messages to process (as a diff between current and latest offsets)
- count of messages read
- number of times the the pull reaches maximum allowed run time
Report metrics via statsd directly, not through counters.