### PR TITLE
Camus staging

### DIFF
--- a/camus-shopify/script/environment.py
+++ b/camus-shopify/script/environment.py
@@ -1,0 +1,8 @@
+import os
+
+environment = os.environ.get('ENVIRONMENT', 'staging')
+
+if environment == 'production':
+    targets = ['camus']
+else:
+    targets = ['camus-staging']

--- a/camus-shopify/script/update_schedule
+++ b/camus-shopify/script/update_schedule
@@ -10,12 +10,7 @@ from os.path import basename, exists
 from azkaban import Job, Project
 from azkaban.remote import Session
 
-environment = os.environ.get('ENVIRONMENT', 'staging')
-
-if environment == 'production':
-    targets = ['camus']
-else:
-    targets = ['camus-staging']
+from environment import environment, targets
 
 formatter = lg.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s', '%d/%m/%y %H:%M:%S')
 ch = lg.StreamHandler(sys.stdout)
@@ -117,8 +112,9 @@ def main():
         session.upload_project(project_name, project_zip)
         logger.info('Successfully uploaded %s zip file.' % project_name)
 
-        schedule_jobs(project_name, session)
-        logger.info('Successfully scheduled %s flow.' % project_name)
+        if environment == 'production':
+            schedule_jobs(project_name, session)
+            logger.info('Successfully scheduled %s flow.' % project_name)
 
 
 if __name__ == '__main__':

--- a/camus-shopify/script/update_schedule
+++ b/camus-shopify/script/update_schedule
@@ -10,7 +10,12 @@ from os.path import basename, exists
 from azkaban import Job, Project
 from azkaban.remote import Session
 
-TARGETS = ['camus']
+environment = os.environ.get('ENVIRONMENT', 'staging')
+
+if environment == 'production':
+    targets = ['camus']
+else:
+    targets = ['camus-staging']
 
 formatter = lg.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s', '%d/%m/%y %H:%M:%S')
 ch = lg.StreamHandler(sys.stdout)
@@ -88,15 +93,15 @@ def camus_project(project_name, target):
 
 def schedule_jobs(project_name, session):
     session.schedule_workflow(project_name, 'Import',                     date='01/01/2015', time="11,30,AM,UTC", period="1h",  concurrent=False)
-    session.schedule_workflow(project_name, 'Watermark',                  date='01/01/2015', time="12,10,AM,UTC", period="30m", concurrent=False)
-    session.schedule_workflow(project_name, 'Late-Arriving-Data Monitor', date='01/01/2015', time="12,20,AM,UTC", period="1h",  concurrent=False)
+    session.schedule_workflow(project_name, 'Watermark',                  date='01/01/2015', time="12,20,AM,UTC", period="1h",  concurrent=False)
+    session.schedule_workflow(project_name, 'Late-Arriving-Data Monitor', date='01/01/2015', time="12,25,AM,UTC", period="1h",  concurrent=False)
 
 def main():
     repo_root = os.getcwd()
     camus_jar = get_camus_version(repo_root)
     azkaban_auth = json.load(open(os.path.join(repo_root, 'camus-shopify', 'azkaban.json')))
 
-    for target in TARGETS:
+    for target in targets:
         project_name = target.title()
         project_zip = "%s.zip" % target
 

--- a/camus-shopify/script/upload
+++ b/camus-shopify/script/upload
@@ -8,7 +8,13 @@ env.host_string = 'management2.ia131.data-chi.shopify.com'
 env.user = 'deploy'
 app_name = 'camus'
 base_path = '/u/apps'
-targets = ['camus']
+
+environment = os.environ.get('ENVIRONMENT', 'staging')
+
+if environment == 'production':
+    targets = ['camus']
+else:
+    targets = ['camus-staging']
 
 jar_path = os.path.join(os.getcwd(), 'camus-shopify', 'target', 'camus-shopify-0.1.0-shopify1.jar')
 

--- a/camus-shopify/script/upload
+++ b/camus-shopify/script/upload
@@ -2,19 +2,13 @@
 import os
 from fabric.api import env
 from fabric.operations import run, put
+from environment import targets
 
 env.forward_agent = True
 env.host_string = 'management2.ia131.data-chi.shopify.com'
 env.user = 'deploy'
 app_name = 'camus'
 base_path = '/u/apps'
-
-environment = os.environ.get('ENVIRONMENT', 'staging')
-
-if environment == 'production':
-    targets = ['camus']
-else:
-    targets = ['camus-staging']
 
 jar_path = os.path.join(os.getcwd(), 'camus-shopify', 'target', 'camus-shopify-0.1.0-shopify1.jar')
 


### PR DESCRIPTION
Quick and Dirty Camus Staging ™️

- Adding notion of environment (reading from an environment variable)
- `ENVIRONMENT` env-var will be set by the ShipIt project we create for staging Camus
- The target `environment` determines which folders we should set-up Camus in

_why multiple targets: In a distant past, we've had to run two Camus in parallel, that's because we had to migrate from reading from one cluster to another and the offsets were all different, so we added support to running multiple Camus in the same 'environment'._

c.c @datwright