### PR TITLE
More stats metrics

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
+++ b/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
@@ -16,19 +16,21 @@ public class CamusWrapper<R> {
     private R record;
     private long timestamp;
     private MapWritable partitionMap;
+    private boolean parsedTimestamp;
 
     public CamusWrapper(R record) {
-        this(record, System.currentTimeMillis());
+        this(record, System.currentTimeMillis(), false);
     }
 
-    public CamusWrapper(R record, long timestamp) {
-        this(record, timestamp, "unknown_server", "unknown_service");
+    public CamusWrapper(R record, long timestamp, boolean parsedTimestamp) {
+        this(record, timestamp, "unknown_server", "unknown_service", parsedTimestamp);
     }
 
-    public CamusWrapper(R record, long timestamp, String server, String service) {
+    public CamusWrapper(R record, long timestamp, String server, String service, boolean parsedTimestamp) {
         this.record = record;
         this.timestamp = timestamp;
         this.partitionMap = new MapWritable();
+        this.parsedTimestamp = parsedTimestamp;
         partitionMap.put(new Text("server"), new Text(server));
         partitionMap.put(new Text("service"), new Text(service));
     }
@@ -71,4 +73,10 @@ public class CamusWrapper<R> {
         return partitionMap;
     }
 
+    /**
+     * Return true if the timestamp was parsed from the message, false otherwise.
+     */
+    public boolean getTimestampParseSuccess() {
+        return parsedTimestamp;
+    }
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import com.linkedin.camus.etl.kafka.reporter.StatsdReporter;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -244,6 +245,8 @@ public class CamusJob extends Configured implements Tool {
     EmailClient.setup(props);
 
     Job job = createJob(props);
+    StatsdReporter.gauge(job.getConfiguration(), "camus-started", 1L);
+
     if (getLog4jConfigure(job)) {
       DOMConfigurator.configure("log4j.xml");
     }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -27,6 +27,7 @@ public class StatsdReporter extends TimeReporter {
   public void report(Job job, Map<String, Long> timingMap) throws IOException {
     super.report(job, timingMap);
     submitCountersToStatsd(job);
+    submitTimingToStatsd(job, timingMap);
   }
 
   private static StatsDClient getClient(Configuration conf) {
@@ -43,6 +44,17 @@ public class StatsdReporter extends TimeReporter {
         for (Counter counter : counterGroup) {
           statsd.gauge(counterGroup.getDisplayName() + "." + counter.getDisplayName(), counter.getValue());
         }
+      }
+    }
+  }
+
+  private void submitTimingToStatsd(Job job, Map<String, Long> timingMap) throws IOException {
+    Configuration conf = job.getConfiguration();
+    if (getStatsdEnabled(conf)) {
+      StatsDClient statsd = getClient(conf);
+      String[] times = new String[]{"pre-setup", "getSplits", "hadoop", "commit", "total"};
+      for (String key : times) {
+        statsd.gauge("run-time" + "." + key, timingMap.get(key));
       }
     }
   }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -120,15 +120,18 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
         }
       }
     }
+    else {
+      log.warn("Message does not have the field " + timestampField); // TODO
+    }
 
     // If timestamp wasn't set in the above block,
     // then set it to current time.
-    if (timestamp == 0) {
+    boolean timestampValid = (timestamp != 0);
+    if (! timestampValid) {
       log.warn("Couldn't find or parse timestamp field '" + timestampField
-          + "' in JSON message, defaulting to current time.");
+              + "' in JSON message, defaulting to current time."); // TODO remove this once we validate the metrics are published correctly
       timestamp = System.currentTimeMillis();
     }
-
-    return new CamusWrapper<String>(payloadString, timestamp);
+    return new CamusWrapper<String>(payloadString, timestamp, timestampValid);
   }
 }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
@@ -77,10 +77,16 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
     messageJsonObject.add("key", keyJsonObject);
 
     long timestamp = getTimestamp(payloadJsonObject);
+    boolean timestampValid = (timestamp != 0);
+    // If timestamp wasn't set in the above block,
+    // then set it to current time.
+    if (! timestampValid) {
+      timestamp = System.currentTimeMillis();
+    }
 
     messageJsonObject.addProperty("timestamp", timestamp);
 
-    return new CamusWrapper<String>(messageJsonObject.toString(), timestamp);
+    return new CamusWrapper<String>(messageJsonObject.toString(), timestamp, timestampValid);
   }
 
   private JsonObject toJson(byte[] bytes) {
@@ -155,14 +161,6 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
           log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
         }
       }
-    }
-
-    // If timestamp wasn't set in the above block,
-    // then set it to current time.
-    if (timestamp == 0) {
-      log.warn("Couldn't find or parse timestamp field '" + timestampField
-          + "' in JSON message, defaulting to current time.");
-      timestamp = System.currentTimeMillis();
     }
     return timestamp;
   }


### PR DESCRIPTION
Submit more data to statsd:
- job start
- run-time stats
- pull-max-time-reached: submit 0 when the partition was fully pulled (this should help with alerting)
- when the timestamp was not found/parsed