### PR TITLE
Remove spam logging.

### DIFF
--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -120,16 +120,11 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
         }
       }
     }
-    else {
-      log.warn("Message does not have the field " + timestampField); // TODO
-    }
 
     // If timestamp wasn't set in the above block,
     // then set it to current time.
     boolean timestampValid = (timestamp != 0);
     if (! timestampValid) {
-      log.warn("Couldn't find or parse timestamp field '" + timestampField
-              + "' in JSON message, defaulting to current time."); // TODO remove this once we validate the metrics are published correctly
       timestamp = System.currentTimeMillis();
     }
     return new CamusWrapper<String>(payloadString, timestamp, timestampValid);


### PR DESCRIPTION
Remove outputing a log line for individual message that has evet_timestamp that's malformed or missing.

This will significantly reduce our map tasks' log size.