### PR TITLE
Better Watermarking and LAD monitoring

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
@@ -1,12 +1,8 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +28,7 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
   private HashMap<String, EtlCounts> counts = new HashMap<String, EtlCounts>();
   private HashMap<String, EtlKey> offsets = new HashMap<String, EtlKey>();
   private HashMap<String, Long> eventCounts = new HashMap<String, Long>();
+  private HashSet<String> pathsWritten = new HashSet<String>();
 
   private TaskAttemptContext context;
   private final RecordWriterProvider recordWriterProvider;
@@ -108,12 +105,16 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
 
           Path dest = new Path(baseOutDir, partitionedFile);
 
-          if (!fs.exists(dest.getParent())) {
-            mkdirs(fs, dest.getParent());
+          Path parentDestPath = dest.getParent();
+          if (!fs.exists(parentDestPath)) {
+            mkdirs(fs, parentDestPath);
           }
 
           commitFile(context, f.getPath(), dest);
           log.info("Moved file from: " + f.getPath() + " to: " + dest);
+
+          // record the fact that we committed data to a path
+          pathsWritten.add(parentDestPath.toString());
 
           if (EtlMultiOutputFormat.isRunTrackingPost(context)) {
             count.writeCountsToMap(allCountObject, fs, new Path(workPath, EtlMultiOutputFormat.COUNTS_PREFIX + "."
@@ -145,6 +146,18 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
       offsetWriter.append(offsets.get(s), NullWritable.get());
     }
     offsetWriter.close();
+
+    // write a list of files that were written
+    ArrayList<String> pathsWrittenList = new ArrayList(pathsWritten);
+    Collections.sort(pathsWrittenList);
+    OutputStream os = fs.create(new Path(super.getWorkPath(), EtlMultiOutputFormat.PATHS_WRITTEN_PREFIX));
+    BufferedWriter br = new BufferedWriter( new OutputStreamWriter( os, "UTF-8" ) );
+    for (String writtenToPath : pathsWrittenList) {
+      br.write(writtenToPath);
+      br.write("\n");
+    }
+    br.close();
+
     super.commitTask(context);
   }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -51,6 +51,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
   public static final DateTimeFormatter FILE_DATE_FORMATTER = DateUtils.getDateTimeFormatter("YYYYMMddHH");
   public static final String OFFSET_PREFIX = "offsets";
+  public static final String PATHS_WRITTEN_PREFIX = "dirs-written-to";
   public static final String ERRORS_PREFIX = "errors";
   public static final String COUNTS_PREFIX = "counts";
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -4,6 +4,7 @@ import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import java.util.Map;
 import java.io.IOException;
+import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
@@ -32,6 +33,12 @@ public class StatsdReporter extends TimeReporter {
 
   private static StatsDClient getClient(Configuration conf) {
     return new NonBlockingStatsDClient("Camus", getStatsdHost(conf), getStatsdPort(conf),
+            new String[] { "camus:counters" });
+  }
+
+  private static StatsDClient getClient(Properties props) {
+    return new NonBlockingStatsDClient("Camus", props.getProperty(STATSD_HOST),
+            Integer.parseInt(props.getProperty(STATSD_PORT, "8125")),
             new String[] { "camus:counters" });
   }
 
@@ -74,6 +81,12 @@ public class StatsdReporter extends TimeReporter {
   public static void gauge(Configuration conf, String metric, Long value, String... tags) {
     if (conf.getBoolean(STATSD_ENABLED, false)) {
       StatsDClient statsd = getClient(conf);
+      statsd.gauge(metric, value, tags);
+    }
+  }
+  public static void gauge(Properties props, String metric, Long value, String... tags) {
+    if (!props.getProperty(STATSD_ENABLED, "false").equals("false")) {
+      StatsDClient statsd = getClient(props);
       statsd.gauge(metric, value, tags);
     }
   }

--- a/camus-shopify/src/main/scala/com/linkedin/camus/shopify/CamusExecutions.scala
+++ b/camus-shopify/src/main/scala/com/linkedin/camus/shopify/CamusExecutions.scala
@@ -2,19 +2,24 @@ package com.linkedin.camus.shopify
 
 import java.util.Properties
 
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
 import com.linkedin.camus.etl.kafka.CamusJob
 import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.log4j.Logger
 import org.wikimedia.analytics.refinery.job.{CamusPartitionChecker, CamusStatusReader}
-
-import scala.collection.mutable.ListBuffer
 
 class CamusExecutions(properties: Properties, fs: FileSystem) {
   val historyFolder = properties.getProperty(CamusJob.ETL_EXECUTION_HISTORY_PATH)
   val camusReader = new CamusStatusReader(fs)
-  val camusRunPath = camusReader.mostRecentRun(new Path(historyFolder))
+
+  val log: Logger = Logger.getLogger(classOf[CamusExecutions])
 
   def topicsAndHoursInWindow(window: Long): Map[String, Seq[(Int, Int, Int, Int)]] = {
+    val camusRunPath = camusReader.mostRecentRun(new Path(historyFolder))
+    log.info(s"Most recent Camus run folder found: $camusRunPath")
     val currentOffsets = camusReader.readEtlKeys(camusReader.offsetsFiles(camusRunPath))
     val currentTopicsAndTimes = camusReader.topicsAndOldestTimes(currentOffsets)
     val checkWindowTopicsAndTimes = currentTopicsAndTimes.mapValues((currentTime) => currentTime - window)
@@ -41,5 +46,26 @@ class CamusExecutions(properties: Properties, fs: FileSystem) {
       }
     }
     list.toList
+  }
+
+  def lastRunDirs(numRuns: Int): List[Path] = camusReader.mostRecentRuns(new Path(historyFolder), numRuns)
+
+  def droppedFoldersInRuns(camusRunPaths: List[Path]): Seq[String] = {
+    val allPathsValid = camusRunPaths.forall(path => fs.exists(new Path(path, EtlMultiOutputFormat.PATHS_WRITTEN_PREFIX)))
+    if (! allPathsValid) {
+      throw new Exception("Some executions paths do not contain expected dirs lists.")
+    }
+
+    val pathsToCheck = mutable.Set[String]()
+    // iterate over folders and collect the paths written in the last runs
+    camusRunPaths.foreach({
+      runPath =>
+        log.info(s"Collecting directories written to in run $runPath")
+        val stream = fs.open(new Path(runPath, EtlMultiOutputFormat.PATHS_WRITTEN_PREFIX))
+        val readLines = Stream.cons(stream.readLine, Stream.continually( stream.readLine))
+        readLines.takeWhile(_ != null).foreach(line => pathsToCheck.add(line))
+        stream.close()
+    })
+    pathsToCheck.toList.sorted
   }
 }

--- a/camus-shopify/src/main/scala/com/linkedin/camus/shopify/LateArrivingDataMonitor.scala
+++ b/camus-shopify/src/main/scala/com/linkedin/camus/shopify/LateArrivingDataMonitor.scala
@@ -7,14 +7,16 @@ import com.linkedin.camus.etl.kafka.reporter.StatsdReporter
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.log4j.Logger
-import org.wikimedia.analytics.refinery.job.CamusStatusReader
 import scopt.OptionParser
 
 object LateArrivingDataMonitor {
   val log: Logger = Logger.getLogger(LateArrivingDataMonitor.getClass)
 
   case class Params(camusPropertiesFilePath: String = "",
-                    window: Long = 1000 * 60 * 60 * 6) // 6 hours window
+                    checkType: String = "window",
+                    window: Long = 1000 * 60 * 60 * 6, // 6 hours window
+                    numRuns: Int = 1
+                   )
 
   val argsParser = new OptionParser[Params]("com.linkedin.camus.shopify.LateArrivingDataMonitor") {
     head("Camus Late Arriving Data Checker", "")
@@ -26,17 +28,44 @@ object LateArrivingDataMonitor {
       p.copy(camusPropertiesFilePath = x)
     } text "Camus configuration properties file path."
 
+    opt[String]('t', "check-type") required() action { (x, p) =>
+      p.copy(checkType = x)
+    } text "Camus check type: \"runs\" or \"window\""
+
     opt[Long]('w', "window") valueName "<window>" action { (x, p) =>
       p.copy(window = x)
-    } text "Camus configuration properties file path."
+    } text "Hours before last offset to check: only applicable in \"window\" type check"
+
+    opt[Int]('r', "num-runs") optional() valueName "<int>" action { (x, p) =>
+      p.copy(numRuns = x)
+    } text "Number of camus runs to check: only applicable in \"runs\" type check."
+
   }
 
 
   def checkDropsInWindow(properties: Properties, fs: FileSystem, window: Long): Boolean = {
+    log.info(s"Running check on folders dropped in the window of $window milliseconds.")
     log.info("Fetching topics and folders to check...")
     val camusExecutions = new CamusExecutions(properties, fs)
-    log.info(s"Checking folders in window ($window) to flag violation...")
     val foldersToCheck = camusExecutions.droppedFoldersInWindow(window)
+
+    log.info(s"Checking folders to flag violation...")
+    checkDrops(properties, fs, foldersToCheck.toList)
+  }
+
+  def checkDropsInRuns(properties: Properties, fs: FileSystem, runs: Int): Boolean = {
+    log.info(s"Running check on folders dropped in the last $runs Camus runs.")
+    val camusExecutions = new CamusExecutions(properties, fs)
+    val camusRunPaths = camusExecutions.lastRunDirs(runs)
+
+    log.info(s"Collecting directories touched in $runs last Camus runs: $camusRunPaths")
+    val foldersToCheck = camusExecutions.droppedFoldersInRuns(camusRunPaths)
+
+    log.info(s"Checking folders to flag violation...")
+    checkDrops(properties, fs, foldersToCheck.toList)
+  }
+
+  def checkDrops(properties: Properties, fs: FileSystem, foldersToCheck: List[String]): Boolean = {
     var violationFound = false
     foldersToCheck.foreach(
       folder => {
@@ -63,14 +92,21 @@ object LateArrivingDataMonitor {
   def main(args: Array[String]): Unit = {
     argsParser.parse(args, Params()) match {
       case Some (params) =>
+        if (! (params.checkType == "window" ||  params.checkType == "runs")) {
+          log.error(s"ERROR: Unknown check type ${params.checkType}")
+          sys.exit(1)
+        }
         log.info("Setting up...")
         val fs = FileSystem.get(new Configuration())
-        val camusReader = new CamusStatusReader(fs)
         val properties: Properties = new Properties()
         properties.load(new FileInputStream(params.camusPropertiesFilePath))
 
-        val violationFound = checkDropsInWindow(properties, fs, params.window)
-
+        val violationFound =
+          if (params.checkType == "window") {
+           checkDropsInWindow(properties, fs, params.window)
+        } else { // runs
+          checkDropsInRuns(properties, fs, params.numRuns)
+        }
         if (violationFound) {
           log.error("ERROR: One or more folders have late-arriving data.")
           sys.exit(1)

--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusStatusReader.scala
@@ -72,14 +72,22 @@ class CamusStatusReader(fs: FileSystem) {
    * @return the most recent run path
    */
   def mostRecentRun(path: Path): Path = {
-      // Filter folders with format YYYY-MM-DD-HH-MM-SS
-      // Sort folders by name DESC
-      val executions = fs.listStatus(path, new RegexpPathFilter("[0-9]{4}(-[0-9]{2}){5}")).map(_.getPath)
-                         .sortWith((f1, f2) => f1.getName().compareTo(f2.getName()) < 0)
-      if (executions.length > 0)
-        executions(executions.length - 1)
-      else
-        throw new IllegalArgumentException("Given Path is doesn't contain camus-run folders.")
+    mostRecentRuns(path).head
+  }
+
+  /**
+   * Finds the most recent runs in a camus-history folder
+   * @return a list of directories for the most recent runs
+   */
+  def mostRecentRuns(path: Path, count: Int = 1): List[Path] = {
+    // Filter folders with format YYYY-MM-DD-HH-MM-SS
+    // Sort folders by name DESC
+    val executions = fs.listStatus(path, new RegexpPathFilter("[0-9]{4}(-[0-9]{2}){5}")).map(_.getPath)
+      .sortWith((f1, f2) => f1.getName().compareTo(f2.getName()) > 0)
+    if (executions.length >= 0)
+      executions.take(count).toList
+    else
+      throw new IllegalArgumentException("Given Path is doesn't contain camus-run folders.")
   }
 
 }


### PR DESCRIPTION
*More logging for LAD*
- Log counts of late-arriving data (e.g. `late-arriving records for dir foo in /data/raw/kafka/foo/2017/11/01/17: 2`)
- Report the fact that there was LAD to Datadog.

*Configurable Watermarking delays*
- Add delay-hours parameter that allows delaying watermarking.
- This allows us to delay watermarking by the specified number of hours.
- Defaults to 0 to preserve current behaviour. The parameter should be set to a sensible value to the Azkaban task in a separate PR.

*LAD check based on paths touched in the last `N` executions*
- For each Camus run, create a file listing all the directories it touched.
- LAD "runs" type check can pick up these files for the last `N` runs and check all the dirs.
- This feature can be activated in a separate PR by changing the Azkaban task.