### PR TITLE
Bug fixes for LAD

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
@@ -150,7 +150,8 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
     // write a list of files that were written
     ArrayList<String> pathsWrittenList = new ArrayList(pathsWritten);
     Collections.sort(pathsWrittenList);
-    OutputStream os = fs.create(new Path(super.getWorkPath(), EtlMultiOutputFormat.PATHS_WRITTEN_PREFIX));
+    OutputStream os = fs.create(new Path(super.getWorkPath(),
+            EtlMultiOutputFormat.getUniqueFile(context, EtlMultiOutputFormat.PATHS_WRITTEN_PREFIX, "")));
     BufferedWriter br = new BufferedWriter( new OutputStreamWriter( os, "UTF-8" ) );
     for (String writtenToPath : pathsWrittenList) {
       br.write(writtenToPath);

--- a/camus-shopify/script/update_schedule
+++ b/camus-shopify/script/update_schedule
@@ -63,7 +63,7 @@ def lad_monitor_job(target):
     monitor_cmd = 'bash -c "'
     monitor_cmd += 'java -Xms1G -Xmx2G -DHADOOP_USER_NAME=deploy -Dlog4j.configuration=file:/u/apps/%(target)s/shared/log4j.xml '
     monitor_cmd += '-cp $(hadoop classpath):/u/apps/%(target)s/current/camus-shopify-0.1.0-shopify1.jar:/etc/camus:/etc/hadoop/conf '
-    monitor_cmd += 'com.linkedin.camus.shopify.LateArrivingDataMonitor -c /u/apps/%(target)s/shared/camus.properties"'
+    monitor_cmd += 'com.linkedin.camus.shopify.LateArrivingDataMonitor -c /u/apps/%(target)s/shared/camus.properties -t window"'
     return monitor_cmd % {'target': target}
 
 def camus_project(project_name, target, env):

--- a/camus-shopify/src/main/scala/com/linkedin/camus/shopify/LateArrivingDataMonitor.scala
+++ b/camus-shopify/src/main/scala/com/linkedin/camus/shopify/LateArrivingDataMonitor.scala
@@ -115,6 +115,7 @@ object LateArrivingDataMonitor {
         }
       case None =>
         log.error("missing arguments, use --help")
+        sys.exit(1)
     }
   }
 }


### PR DESCRIPTION
- Add the default (window) type check command line argument for LAD.
- Fail the LAD task when it's not correctly configured.
- Write one file list per mapper task; collect all touched dirs from them.