### PR TITLE
Do not overwrite existing flag.

### DIFF
--- a/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
+++ b/camus-shopify/src/main/scala/org/wikimedia/analytics/refinery/job/CamusPartitionChecker.scala
@@ -128,11 +128,16 @@ object CamusPartitionChecker {
         val partitionPath: Path = new Path(dir)
         if (fs.exists(partitionPath) && fs.isDirectory(partitionPath)) {
           val flagPath = new Path(s"${dir}/${flag}")
-          if (! dryRun) {
-            fs.create(flagPath)
-            log.info(s"Flag created: ${dir}/${flag}")
-          } else
-            log.info(s"DryRun - Flag would have been created: ${dir}/${flag}")
+          if (! fs.exists(flagPath)) {
+            if (! dryRun) {
+              fs.create(flagPath)
+              log.info(s"Flag created: ${dir}/${flag}")
+            } else
+              log.info(s"DryRun - Flag would have been created: ${dir}/${flag}")
+          }
+          else {
+            log.warn(s"Flag already exists: ${flagPath.toString}")
+          }
         } else
           log.warn(s"Folder does not exist for hour $partitionPath. Can't flag it.")
       }


### PR DESCRIPTION
Before creating a flag, check if one exists and if so output a warning and do not update it.