### PR TITLE
Changing from overwriting files to swapping symlinks

### DIFF
--- a/camus-shopify/script/upload
+++ b/camus-shopify/script/upload
@@ -14,13 +14,19 @@ jar_path = os.path.join(os.getcwd(), 'camus-shopify', 'target', 'camus-shopify-0
 gcs_script_path = os.path.join(os.getcwd(), 'camus-shopify', 'script', 'upload_to_gcs.py')
 gcs_topics_to_upload = os.path.join(os.getcwd(), 'camus-shopify', 'script', 'upload_topics_to_gcs')
 venv = os.path.join(os.getcwd(), 'camus-shopify', 'script', 'venv')
+sha = os.environ['SHA']
 
 for target in targets:
-    target_dir = '/'.join([base_path, target, 'current'])
+    target_dir = '/'.join([base_path, target, sha])
+    canonical_dest = '/'.join([base_path, target, 'current'])
+
     run('mkdir -p %s' % target_dir)
+
     put(jar_path, target_dir)
     put(gcs_script_path, target_dir)
     put(gcs_topics_to_upload, target_dir)
     put(venv, target_dir)
+
+    run('ln -sfn %s %s' % (target_dir, canonical_dest))
 
 print('Completed upload')


### PR DESCRIPTION
Instead of overwriting files (more importantly the main jar) per deploy, we'll now upload multiple versions and keep a symlink to the canonical location (`current/`). This will allow us to safely deploy even if Camus is running 😰😰