### PR TITLE
Sending StatsD events for non-fatal errors

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -370,7 +370,7 @@ public class CamusJob extends Configured implements Tool {
     stopTiming("hadoop");
     startTiming("commit");
 
-    boolean hadExecutionErrors = checkExecutionErrors(fs, newExecutionOutput);
+    boolean hadExecutionErrors = checkExecutionErrors(fs, newExecutionOutput, job.getConfiguration());
 
     checkIfTooManySkippedMsg(counters);
 
@@ -522,7 +522,8 @@ public class CamusJob extends Configured implements Tool {
   }
 
   private boolean checkExecutionErrors(final FileSystem fs,
-                                       final Path newExecutionOutput) throws IOException {
+                                       final Path newExecutionOutput,
+                                       Configuration configuration) throws IOException {
     Map<String, List<Pair<EtlKey, ExceptionWritable>>> errors = readErrors(fs, newExecutionOutput);
 
     // Print any potential errors encountered
@@ -534,12 +535,14 @@ public class CamusJob extends Configured implements Tool {
       final List<Pair<EtlKey, ExceptionWritable>> errorsFromFile = fileEntry.getValue();
       if (errorsFromFile.size() > 0) {
         log.error("Errors from file [" + filePath + "]");
+        StatsdReporter.gauge(configuration, "camus-errors", 1L);
       }
 
       for (final Pair<EtlKey, ExceptionWritable> errorEntry : errorsFromFile) {
         final EtlKey errorKey = errorEntry.getKey();
         final ExceptionWritable errorValue = errorEntry.getValue();
         log.error("Error for EtlKey [" + errorKey + "]: " + errorValue.toString());
+        StatsdReporter.gauge(configuration, "camus-errors", 1L);
       }
     }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -535,7 +535,6 @@ public class CamusJob extends Configured implements Tool {
       final List<Pair<EtlKey, ExceptionWritable>> errorsFromFile = fileEntry.getValue();
       if (errorsFromFile.size() > 0) {
         log.error("Errors from file [" + filePath + "]");
-        StatsdReporter.gauge(configuration, "camus-errors", 1L);
       }
 
       for (final Pair<EtlKey, ExceptionWritable> errorEntry : errorsFromFile) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -10,6 +10,7 @@ import com.linkedin.camus.etl.kafka.common.EmailClient;
 import com.linkedin.camus.etl.kafka.common.EtlKey;
 import com.linkedin.camus.etl.kafka.common.EtlRequest;
 import com.linkedin.camus.etl.kafka.common.LeaderInfo;
+import com.linkedin.camus.etl.kafka.reporter.StatsdReporter;
 import com.linkedin.camus.workallocater.CamusRequest;
 import com.linkedin.camus.workallocater.WorkAllocator;
 
@@ -435,6 +436,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
         camusRequestEmailMessage +=
                 "The current offset is too close to the earliest offset, Camus might be falling behind: "
                     + request + "\n";
+        StatsdReporter.gauge(context.getConfiguration(), "close-to-earliest-offset", 1L, key.statsdTags());
       }
       log.info(request);
     }


### PR DESCRIPTION
File errors and ETL errors that get rescued by the system get logged at the end of the execution. We want to also emit an event to StatsD so we properly track it.


Mmm, so I was able to test it locally but reproducing a kafka reading exception.

@olessia `camus-errors` too generic a metric name?
