### PR TITLE
Set Service line to Data Science & Engineering

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,5 @@
 # https://services.shopify.io/services/camus/production
+org_line: Data Science & Engineering
 director: davidlennie
 owners:
 - Shopify/data-acquisition


### PR DESCRIPTION
**Owners**: @Shopify/data-acquisition
**Service**: [camus/production](https://services.shopify.io/services/camus/production)

This service has been automatically defined as being part of the Data Science & Engineering service line.

Please confirm by merging or changing the `org_line` in `service.yml` to one of these product or service lines:

**Product lines:**

* App & Partner Platform
* Channels
* International Growth
* Media
* Shipping Services
* Shopify Core
* Shopify Money
* Shopify Plus
* Shopify Pre

**Service lines:**

* Corporate
* Corporate Affairs
* Data Science & Engineering
* Finance
* HR & Culture
* Internal Operations
* Legal
* Marketing
* Production Engineering
* RnD Programs
* Support
* Trust

For more context about this change, please check [this](https://development.shopify.io/announcements/product_service_lines_servicesdb/) announcement.
